### PR TITLE
docs: add CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,25 @@
+# Changelog
+
+All notable changes to MakerChecker are documented here. The format follows
+[Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and the project
+follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [1.0.0] - 2026-06-15
+
+First public release.
+
+### Added
+
+- Roles, agents, and versioned skills (MCP/HTTP/local) with risk tiers; deny-by-default grants with revocation.
+- Segregation-of-duties constraints enforced at both decision and invocation time.
+- Flows with approval gates, retries, timeouts, and a crash-recovery watchdog.
+- n-of-m named approvals: quorums, named approver lists, and requester self-approval forbidden by default (fail closed).
+- Enforced role limits and budgets: per-skill invocation caps, fail-closed amount ceilings, run-level invocation and token budgets.
+- Proxy sessions wrapping LangGraph, CrewAI, and Claude Agent SDK agents with grant checks, SoD, and the audit trail; a typed LangChain connector plus generic middleware recipes.
+- Hash-chained, append-only audit log with Ed25519-signed, offline-verifiable export bundles and a CLI verifier.
+- Evidence packs: self-contained HTML run reports and role/grant/SoD access-review reports.
+- Cron, event, and manual/API triggers; HMAC-signed outbound webhooks with retries and a failure counter.
+- Real-model execution (Anthropic, Gemini/OpenAI-compatible) with a deterministic, air-gapped fallback.
+- API-key auth, a React UI (run viewer, approvals inbox, registry), a typed SDK, and an OpenAPI document.
+
+[1.0.0]: https://github.com/sammysltd/makerchecker/releases/tag/v1.0.0

--- a/README.md
+++ b/README.md
@@ -162,4 +162,4 @@ On April 17, 2026 the Federal Reserve replaced SR 11-7 with SR 26-2, which expli
 
 Licensing rationale and the commercial/CLA model: [LICENSING.md](LICENSING.md). The audit chain is specified for independent offline verification ([audit spec](docs/audit-spec.md)); security reports are welcome ([SECURITY.md](SECURITY.md)).
 
-Contributing: [CONTRIBUTING.md](CONTRIBUTING.md) · Security: [SECURITY.md](SECURITY.md) · Code of Conduct: [CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md) · Starter issues: [docs/good-first-issues.md](docs/good-first-issues.md)
+Contributing: [CONTRIBUTING.md](CONTRIBUTING.md) · Security: [SECURITY.md](SECURITY.md) · Code of Conduct: [CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md) · Changelog: [CHANGELOG.md](CHANGELOG.md) · Starter issues: [docs/good-first-issues.md](docs/good-first-issues.md)


### PR DESCRIPTION
Adds a Keep-a-Changelog CHANGELOG.md with the 1.0.0 entry and links it from the README footer. Closes the missing-changelog gap noted in the launch review. Also validates that the human-contributor PR path passes CI under branch protection (the gitleaks pull_request fix).