### PR TITLE
fix(security): block IPv4-compatible IPv6 (::a.b.c.d) in SSRF guard

### DIFF
--- a/packages/server/src/skills/invoker.security.test.ts
+++ b/packages/server/src/skills/invoker.security.test.ts
@@ -403,6 +403,9 @@ describe("assertSafeHttpUrl (SSRF guard)", () => {
     "http://[fd12:3456::1]/x", // unique-local
     "http://[::ffff:127.0.0.1]/x", // IPv4-mapped loopback
     "http://[::ffff:169.254.169.254]/x", // IPv4-mapped metadata
+    "http://[::169.254.169.254]/x", // IPv4-compatible metadata (canonicalizes to ::a9fe:a9fe)
+    "http://[::127.0.0.1]/x", // IPv4-compatible loopback (canonicalizes to ::7f00:1)
+    "http://[::10.0.0.1]/x", // IPv4-compatible private (canonicalizes to ::a00:1)
   ])("rejects private/loopback/link-local IPv6 %s", (u) => {
     expectInputInvalid(() => assertSafeHttpUrl(u), /blocked|loopback|private/);
   });
@@ -438,6 +441,19 @@ describe("assertSafeHttpUrl (SSRF guard)", () => {
     expect(isBlockedIpv4("8.8.8.8")).toBe(false);
     expect(isBlockedIpv6("::1")).toBe(true);
     expect(isBlockedIpv6("2606:4700:4700::1111")).toBe(false);
+  });
+
+  it("blocks IPv4-compatible IPv6 (::a.b.c.d) in canonicalized hex form", () => {
+    // The WHATWG URL parser rewrites ::169.254.169.254 -> ::a9fe:a9fe etc., so
+    // the classifier must decode the trailing hextets and judge by the IPv4.
+    expect(isBlockedIpv6("::a9fe:a9fe")).toBe(true); // 169.254.169.254 metadata
+    expect(isBlockedIpv6("::7f00:1")).toBe(true); // 127.0.0.1 loopback
+    expect(isBlockedIpv6("::a00:1")).toBe(true); // 10.0.0.1 private
+    expect(isBlockedIpv6("::ac10:1")).toBe(true); // 172.16.0.1 private
+    expect(isBlockedIpv6("::c0a8:1")).toBe(true); // 192.168.0.1 private
+    // A public IPv4 embedded in a compatible/mapped address stays allowed.
+    expect(isBlockedIpv6("::ffff:808:808")).toBe(false); // 8.8.8.8 (mapped)
+    expect(isBlockedIpv6("::808:808")).toBe(false); // 8.8.8.8 (compatible)
   });
 });
 

--- a/packages/server/src/skills/invoker.ts
+++ b/packages/server/src/skills/invoker.ts
@@ -787,10 +787,12 @@ export function isBlockedIpv6(ip: string): boolean {
   const dotted = addr.match(/(?:::ffff:|::)(\d+\.\d+\.\d+\.\d+)$/);
   if (dotted?.[1]) return isBlockedIpv4(dotted[1]);
 
-  // IPv4-mapped written in hex form. The WHATWG URL parser canonicalizes
-  // ::ffff:127.0.0.1 -> ::ffff:7f00:1, so decode the trailing two hextets
-  // back into an IPv4 address to prevent bypass via the v6 encoding.
-  const hexMapped = addr.match(/^::ffff:([0-9a-f]{1,4}):([0-9a-f]{1,4})$/);
+  // IPv4-mapped (::ffff:...) and IPv4-compatible (::...) addresses written in
+  // hex form. The WHATWG URL parser canonicalizes the dotted tail to hex, so
+  // ::ffff:127.0.0.1 -> ::ffff:7f00:1 and ::127.0.0.1 -> ::7f00:1. Decode the
+  // trailing two hextets back into an IPv4 address and classify by it, so a
+  // private/loopback/metadata target cannot slip through either v6 encoding.
+  const hexMapped = addr.match(/^::(?:ffff:)?([0-9a-f]{1,4}):([0-9a-f]{1,4})$/);
   if (hexMapped?.[1] && hexMapped[2]) {
     const hi = Number.parseInt(hexMapped[1], 16);
     const lo = Number.parseInt(hexMapped[2], 16);

--- a/packages/server/src/skills/ssrf-guard.test.ts
+++ b/packages/server/src/skills/ssrf-guard.test.ts
@@ -82,6 +82,9 @@ describe("isBlockedResolvedAddress (reuses the literal-IP ruleset)", () => {
     ["fd12:3456::1", 6], // unique-local
     ["::ffff:127.0.0.1", 6], // IPv4-mapped loopback
     ["::ffff:169.254.169.254", 6], // IPv4-mapped metadata
+    ["::7f00:1", 6], // IPv4-compatible loopback (127.0.0.1 in hex)
+    ["::a9fe:a9fe", 6], // IPv4-compatible metadata (169.254.169.254 in hex)
+    ["::a00:1", 6], // IPv4-compatible private (10.0.0.1 in hex)
   ] as const)("blocks private/loopback/link-local IPv6 %s", (ip, fam) => {
     expect(isBlockedResolvedAddress(ip, fam)).toBe(true);
   });


### PR DESCRIPTION
## Problem
The IPv6 SSRF classifier (`isBlockedIpv6`) only decoded the IPv4-**mapped** hex form (`::ffff:HHHH:HHHH`). An internal target written as an IPv4-**compatible** address, e.g. `http://[::169.254.169.254]`, is canonicalized by the WHATWG URL parser to `::a9fe:a9fe` and slipped through both `assertSafeHttpUrl` and the connect-time DNS-rebinding pin (`resolveAndCheckHost` -> `isBlockedIpv6`). Deny-by-default failure: an address the guard could not prove safe was allowed.

## Fix
One-line regex change: make the `ffff:` prefix optional so the mapped and compatible hex forms both decode to the embedded IPv4 and get classified. Public IPv4 embedded in such addresses (`::808:808` = 8.8.8.8) stays allowed; real public IPv6 cannot match the two-hextet shape.

## Tests
Adversarial cases added on all three paths: static (`assertSafeHttpUrl`), resolver (`isBlockedResolvedAddress`), and the literal classifier (`isBlockedIpv6`), covering loopback/metadata/private compatible forms plus public-preservation. 150 unit tests pass locally.