### PR TITLE
fix(engine): guard step terminal writes + enqueue first advance in-tx

### DIFF
--- a/packages/server/src/boot/cron.integration.test.ts
+++ b/packages/server/src/boot/cron.integration.test.ts
@@ -1,5 +1,7 @@
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
 
+import { makeWorkerUtils } from "graphile-worker";
+
 import { createTestDb, type TestDb } from "../../test/test-db.js";
 import { seedDemo } from "../demo/seed.js";
 import { GraphileWorkerBackend } from "../engine/graphile-backend.js";
@@ -38,6 +40,14 @@ beforeAll(async () => {
     "SELECT id FROM flow_triggers WHERE type = 'cron'",
   );
   demoTriggerId = rows[0]!.id;
+
+  // startRun enqueues the first advance in the same transaction (via
+  // graphile_worker.add_job), so the worker schema must exist before any run is
+  // started. Install it here without a runner: this suite intentionally has no
+  // worker, so the runs it starts sit queued, which is what we want to inspect.
+  const utils = await makeWorkerUtils({ pgPool: db.pool });
+  await utils.migrate();
+  await utils.release();
 
   // The handler only needs enqueue (no runner): runs it starts sit queued,
   // which is exactly what we want to inspect.

--- a/packages/server/src/engine/engine.integration.test.ts
+++ b/packages/server/src/engine/engine.integration.test.ts
@@ -896,3 +896,89 @@ describe("backoff", () => {
     expect(backoffDelayMs(1)).toBe(2000); // default = exponential
   });
 });
+
+describe("engine robustness: race + crash safety", () => {
+  async function waitForStepSettled(runId: string, timeoutMs = 15_000): Promise<string> {
+    const deadline = Date.now() + timeoutMs;
+    for (;;) {
+      const { rows } = await db.pool.query<{ status: string }>(
+        "SELECT status FROM step_runs WHERE run_id = $1 ORDER BY step_index DESC LIMIT 1",
+        [runId],
+      );
+      const status = rows[0]?.status;
+      if (status && status !== "running" && status !== "pending") return status;
+      if (Date.now() > deadline) throw new Error(`step for ${runId} never settled (at "${status}")`);
+      await new Promise((r) => setTimeout(r, 50));
+    }
+  }
+
+  // ADVERSARIAL: the watchdog (or a retried delivery) fails an attempt while it
+  // is still executing. The completed-write must NOT resurrect the failed step.
+  it("does not resurrect a step the watchdog failed mid-execution", async () => {
+    await seedAgent("race-agent");
+    // The skill simulates the watchdog timing out THIS attempt while it runs:
+    // it flips the (only) running step_run to timed_out before returning. When
+    // executeStep then reaches its guarded completed-write, the row is no longer
+    // 'running', so it must be left as timed_out rather than flipped to completed.
+    await seedSkill("race-skill@1", async () => {
+      await db.pool.query(
+        `UPDATE step_runs SET status = 'timed_out', error = '{"message":"watchdog"}', finished_at = now()
+           WHERE status = 'running'`,
+      );
+      return { ok: true };
+    });
+    await grant("race-agent", "race-skill@1");
+    const { flowVersionId } = await publishFlowVersion(db.pool, {
+      definition: {
+        name: "race-flow",
+        steps: [{ key: "s", agent: "race-agent", skills: ["race-skill@1"] }],
+      },
+      actor: USER,
+    });
+
+    const runId = await startRun(ctx, { flowVersionId, triggeredBy: USER });
+    expect(await waitForStepSettled(runId)).toBe("timed_out"); // NOT resurrected to completed
+
+    const { rows } = await db.pool.query<{ status: string }>(
+      "SELECT status FROM step_runs WHERE run_id = $1",
+      [runId],
+    );
+    expect(rows.every((r) => r.status === "timed_out")).toBe(true);
+    // No completed event was emitted for the resurrected attempt.
+    expect(await eventTypes(runId)).not.toContain("run.step.completed");
+    // The chain stays internally consistent regardless of the race.
+    expect((await verifyChain(db.pool)).ok).toBe(true);
+  });
+
+  // ADVERSARIAL: a crash (or outage) of the queue's enqueue path between the run
+  // INSERT and the first advance must not orphan the run. The fix enqueues the
+  // first advance in the SAME transaction as the run row, so a broken
+  // backend.enqueue cannot prevent the run from advancing.
+  it("starts a run even when backend.enqueue is broken (in-tx first advance)", async () => {
+    await seedAgent("crash-agent");
+    await seedSkill("crash-skill@1", async (input) => ({ ...input, ran: true }));
+    await grant("crash-agent", "crash-skill@1");
+    const { flowVersionId } = await publishFlowVersion(db.pool, {
+      definition: {
+        name: "crash-flow",
+        steps: [{ key: "s", agent: "crash-agent", skills: ["crash-skill@1"] }],
+      },
+      actor: USER,
+    });
+
+    // A backend whose enqueue() throws. Pre-fix, startRun called this and would
+    // reject, orphaning the run. Post-fix, startRun never calls it (the advance
+    // job is written in-tx) and the real worker still picks the job up.
+    const brokenBackend = Object.create(ctx.backend) as typeof ctx.backend;
+    brokenBackend.enqueue = async () => {
+      throw new Error("backend.enqueue is down");
+    };
+
+    const runId = await startRun(
+      { ...ctx, backend: brokenBackend },
+      { flowVersionId, triggeredBy: USER },
+    );
+    expect(await waitForRunStatus(runId, ["completed", "failed"])).toBe("completed");
+    expect((await verifyChain(db.pool)).ok).toBe(true);
+  });
+});

--- a/packages/server/src/engine/orchestrator.ts
+++ b/packages/server/src/engine/orchestrator.ts
@@ -98,6 +98,11 @@ export async function startRun(
         input: redactValue(resolveRedactionHook(), input.runInput ?? {}),
       },
     });
+    // Enqueue the first advance INSIDE the transaction (graphile_worker writes to
+    // the same Postgres), so the run row and its advance job commit atomically. A
+    // crash between COMMIT and a separate enqueue would otherwise orphan the run
+    // with no recovery sweep. advanceRun is idempotent, so a replay is safe.
+    await enqueueInTx(client, TASK_ADVANCE, { runId }, { jobKey: `advance:${runId}` });
     await client.query("COMMIT");
   } catch (err) {
     await client.query("ROLLBACK");
@@ -105,7 +110,6 @@ export async function startRun(
   } finally {
     client.release();
   }
-  await ctx.backend.enqueue(TASK_ADVANCE, { runId }, { jobKey: `advance:${runId}` });
   return runId;
 }
 
@@ -335,10 +339,17 @@ export async function executeStep(ctx: EngineContext, stepRunId: string): Promis
     await client.query("SELECT pg_advisory_xact_lock(hashtext('run:' || $1::text))", [runId]);
 
     if (failure === null) {
-      await client.query(
-        `UPDATE step_runs SET status = 'completed', output = $2, finished_at = now() WHERE id = $1`,
+      const updated = await client.query(
+        `UPDATE step_runs SET status = 'completed', output = $2, finished_at = now()
+           WHERE id = $1 AND status = 'running' RETURNING id`,
         [stepRunId, JSON.stringify(output)],
       );
+      if (updated.rowCount === 0) {
+        // The watchdog (or another delivery) already settled this attempt under
+        // the same lock. Do not resurrect it: skip the completed event + advance.
+        await client.query("COMMIT");
+        return;
+      }
       await recordEvent(client, {
         eventType: "run.step.completed",
         actor: { type: "agent", id: stepRun.agent_id, name: step.agent },
@@ -683,10 +694,18 @@ export async function handleStepFailure(
   pending?: PendingWebhook[],
 ): Promise<void> {
   const status = args.timedOut ? "timed_out" : "failed";
-  await client.query(
-    `UPDATE step_runs SET status = $2, error = $3, finished_at = now() WHERE id = $1`,
+  const updated = await client.query(
+    `UPDATE step_runs SET status = $2, error = $3, finished_at = now()
+       WHERE id = $1 AND status = 'running' RETURNING id`,
     [args.stepRunId, status, JSON.stringify({ message: args.reason })],
   );
+  if (updated.rowCount === 0) {
+    // Another actor (the watchdog, or a retried delivery) already settled this
+    // attempt under the same lock. Skip the retry/failed audit events and
+    // failRun so the terminal state is never double-emitted. The watchdog caller
+    // re-checks status='running' before calling here, so it is unaffected.
+    return;
+  }
 
   // Error/reason text is attacker-influenced (e.g. a forwarded MCP/HTTP skill
   // error) and can carry secrets, so redact it before it enters the audit chain.


### PR DESCRIPTION
Two verified robustness bugs from an internal audit, both low-risk fixes matching existing idioms.

## 1. Step status-write race (HIGH)
`executeStep`'s completed-write and `handleStepFailure`'s failure-write had no `WHERE status = 'running'` predicate. If the watchdog (or a retried delivery) had already settled an attempt, the slow path would overwrite it (e.g. resurrect a `timed_out` step to `completed`), corrupting run state and emitting a post-terminal audit event. Both writes are now guarded with `AND status = 'running' RETURNING id` and skip their side effects (completed/failed events, advance enqueue, failRun) when no row is updated. Mirrors the existing guarded idiom at orchestrator.ts:550.

## 2. Orphaned run on crash (HIGH)
`startRun` enqueued the first advance with `backend.enqueue` *after* the COMMIT. A crash between the two orphaned the run (no pending-run recovery sweep exists). The first advance is now enqueued **in the same transaction** as the run row via `enqueueInTx` (graphile_worker writes to the same Postgres), so they commit atomically. `advanceRun` is idempotent (per-run advisory lock + terminal short-circuit), so a replayed job is safe. Matches the 4 other in-tx enqueue sites.

## Tests
Two adversarial integration tests: (1) a step the watchdog fails mid-execution is left `timed_out` with no `run.step.completed` event (not resurrected); (2) a run still starts and completes when `backend.enqueue` throws (proving the in-tx first advance). Full engine integration suite (38 tests) green locally; audit chain verifies in both.