### PR TITLE
fix(api): global error handler + UUID param validation

### DIFF
--- a/packages/server/src/app.test.ts
+++ b/packages/server/src/app.test.ts
@@ -129,6 +129,56 @@ describe("security hardening", () => {
     });
   });
 
+  describe("id param validation and error handling", () => {
+    afterEach(() => {
+      delete process.env.MAKERCHECKER_AUTH_DISABLED;
+    });
+
+    it("returns 400 (not a 500 + Postgres leak) for a non-UUID run id", async () => {
+      process.env.MAKERCHECKER_AUTH_DISABLED = "1";
+      const app = await buildApp(stubCtx);
+      const res = await app.inject({ method: "GET", url: "/api/runs/not-a-uuid" });
+      expect(res.statusCode).toBe(400);
+      expect(res.body).not.toContain("22P02");
+      await app.close();
+    });
+
+    it("returns 400 for a non-UUID approval id", async () => {
+      process.env.MAKERCHECKER_AUTH_DISABLED = "1";
+      const app = await buildApp(stubCtx);
+      const res = await app.inject({
+        method: "POST",
+        url: "/api/approvals/not-a-uuid/decision",
+        payload: { decision: "approved" },
+      });
+      expect(res.statusCode).toBe(400);
+      await app.close();
+    });
+
+    it("returns a generic 500 without leaking an internal error message", async () => {
+      // A ctx whose query throws an infra error carrying host:port + a secret.
+      const throwingCtx = {
+        pool: {
+          query: async () => {
+            throw new Error("connect ECONNREFUSED 10.0.3.5:5432 internal-db.secret.host");
+          },
+        },
+      } as unknown as EngineContext;
+      process.env.MAKERCHECKER_AUTH_DISABLED = "1";
+      const app = await buildApp(throwingCtx);
+      const res = await app.inject({
+        method: "GET",
+        url: "/api/runs/11111111-1111-1111-1111-111111111111",
+      });
+      expect(res.statusCode).toBe(500);
+      expect(res.json()).toEqual({ error: "internal error" });
+      // The raw error message (DB host:port, secret) must not reach the client.
+      expect(res.body).not.toContain("ECONNREFUSED");
+      expect(res.body).not.toContain("secret.host");
+      await app.close();
+    });
+  });
+
   describe("rate limiting", () => {
     const ORIGINAL_NODE_ENV = process.env.NODE_ENV;
     afterEach(() => {

--- a/packages/server/src/app.ts
+++ b/packages/server/src/app.ts
@@ -55,6 +55,12 @@ const DecisionBody = Type.Object(
   { additionalProperties: false },
 );
 
+// Route :id params are UUIDs. Validating the format up front turns a malformed
+// id into a clean 400 instead of letting it reach a uuid-typed query and throw
+// a raw Postgres 22P02 (500). Matches the admin/proxy routes' IdParams.
+const UUID_PATTERN = "^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$";
+const IdParams = Type.Object({ id: Type.String({ pattern: UUID_PATTERN }) });
+
 /**
  * The MakerChecker API: run/approval endpoints plus admin CRUD (see
  * api/admin-routes.ts). All API routes live under the /api prefix so they
@@ -73,6 +79,19 @@ export async function buildApp(ctx?: EngineContext): Promise<FastifyInstance> {
   const app = Fastify({
     logger: false,
     ajv: { customOptions: { removeAdditional: false } },
+  });
+
+  // Global error handler. Deliberate domain responses (reply.status(4xx).send)
+  // never reach here. For an UNCAUGHT/re-thrown error: pass <500 through (this
+  // preserves Fastify's FST_ERR_VALIDATION 400 messages), but for >=500 log the
+  // full error server-side and return a generic body so infrastructure details
+  // (DB host:port, pg driver codes, stack traces) are never disclosed to a caller.
+  app.setErrorHandler((err, req, reply) => {
+    const status =
+      (err as { statusCode?: number }).statusCode ?? (err as { status?: number }).status ?? 500;
+    if (status < 500) return reply.status(status).send(err);
+    req.log.error({ err }, "unhandled error");
+    return reply.status(500).send({ error: "internal error" });
   });
 
   // Security middleware, registered BEFORE any route so it covers /healthz,
@@ -293,7 +312,7 @@ async function registerApiRoutes(
 
   api.get<{ Params: { id: string } }>(
     "/runs/:id",
-    { schema: { operationId: "getRun", tags: ["runs"] } },
+    { schema: { operationId: "getRun", tags: ["runs"], params: IdParams } },
     async (req, reply) => {
       // Object-level read scope: a non-admin must not learn about another
       // actor's run. Deny before any row is fetched, with the same 404 a
@@ -441,6 +460,7 @@ async function registerApiRoutes(
       schema: {
         operationId: "decideApproval",
         tags: ["approvals"],
+        params: IdParams,
         // additionalProperties:false locks the body to {decision, reason?} so a
         // decider cannot smuggle extra fields into the handler. The handler's
         // own check (below) still rejects an unknown decision value with a


### PR DESCRIPTION
Two low-risk API-hardening fixes from the internal audit.

## 1. No global error handler -> raw error/PG-code leak (MED)
Fastify's default handler echoes `error.message` for any uncaught/re-thrown error, leaking DB host:port and pg driver codes to clients. Added a `setErrorHandler`: deliberate domain 4xx pass through verbatim (validation messages preserved), but `>=500` logs server-side and returns a generic `{ error: "internal error" }`.

## 2. Missing UUID params schema -> 500 + 22P02 leak (LOW)
`GET /runs/:id` and `POST /approvals/:id/decision` were the only id-taking routes without a params schema, so a non-UUID id reached a uuid-typed query and threw a raw Postgres 22P02 (500). Added `IdParams` (matching the admin/proxy routes) so a malformed id is a clean 400.

## Tests
Non-UUID ids return 400 (no `22P02` in body); a thrown infra error returns 500 with a generic body and no host/secret leak. Full server suite (594 tests) green, coverage 97.38%.