### PR TITLE
fix(shared): bound flow-definition size to cap POST /flows amplification

### DIFF
--- a/packages/shared/src/flow-definition.test.ts
+++ b/packages/shared/src/flow-definition.test.ts
@@ -153,6 +153,131 @@ describe("approval gate approvals object (n-of-m)", () => {
   });
 });
 
+describe("size bounds (POST /flows amplification guard)", () => {
+  // A single oversized definition must not be allowed to amplify into tens of
+  // thousands of serial DB queries; the grammar caps the blast radius.
+  const agentStep = (i: number) => ({
+    key: `step_${i}`,
+    agent: "a",
+    skills: ["s@1"],
+  });
+
+  it("accepts a definition at the step ceiling (200)", () => {
+    const result = validateFlowDefinition({
+      name: "f",
+      steps: Array.from({ length: 200 }, (_, i) => agentStep(i)),
+    });
+    expect(result.ok).toBe(true);
+    if (result.ok) expect(result.definition.steps).toHaveLength(200);
+  });
+
+  it("rejects a definition over the step ceiling (201)", () => {
+    const result = validateFlowDefinition({
+      name: "f",
+      steps: Array.from({ length: 201 }, (_, i) => agentStep(i)),
+    });
+    expect(result.ok).toBe(false);
+  });
+
+  it("accepts an agent step at the skills ceiling (50)", () => {
+    const result = validateFlowDefinition({
+      name: "f",
+      steps: [
+        { key: "s", agent: "a", skills: Array.from({ length: 50 }, (_, i) => `skill-${i}@1`) },
+      ],
+    });
+    expect(result.ok).toBe(true);
+  });
+
+  it("rejects an agent step over the skills ceiling (51)", () => {
+    const result = validateFlowDefinition({
+      name: "f",
+      steps: [
+        { key: "s", agent: "a", skills: Array.from({ length: 51 }, (_, i) => `skill-${i}@1`) },
+      ],
+    });
+    expect(result.ok).toBe(false);
+  });
+
+  it("rejects an approval gate over the approver_emails ceiling (101)", () => {
+    const result = validateFlowDefinition({
+      name: "f",
+      steps: [
+        { key: "work", agent: "a", skills: ["s@1"] },
+        {
+          key: "gate",
+          type: "approval_gate",
+          title: "T",
+          approvals: {
+            approver_emails: Array.from({ length: 101 }, (_, i) => `u${i}@bank.example`),
+          },
+        },
+      ],
+    });
+    expect(result.ok).toBe(false);
+  });
+
+  it("accepts an approval gate at the approver_emails ceiling (100)", () => {
+    const result = validateFlowDefinition({
+      name: "f",
+      steps: [
+        { key: "work", agent: "a", skills: ["s@1"] },
+        {
+          key: "gate",
+          type: "approval_gate",
+          title: "T",
+          approvals: {
+            approver_emails: Array.from({ length: 100 }, (_, i) => `u${i}@bank.example`),
+          },
+        },
+      ],
+    });
+    expect(result.ok).toBe(true);
+  });
+
+  it("rejects over-long free-text fields", () => {
+    // instructions: maxLength 4000
+    expect(
+      validateFlowDefinition({
+        name: "f",
+        steps: [{ key: "s", agent: "a", skills: ["s@1"], instructions: "x".repeat(4001) }],
+      }).ok,
+    ).toBe(false);
+    // name: maxLength 200
+    expect(
+      validateFlowDefinition({
+        name: "a".repeat(201),
+        steps: [{ key: "s", agent: "a", skills: ["s@1"] }],
+      }).ok,
+    ).toBe(false);
+    // step key: maxLength 200
+    expect(
+      validateFlowDefinition({
+        name: "f",
+        steps: [{ key: `s${"a".repeat(200)}`, agent: "a", skills: ["s@1"] }],
+      }).ok,
+    ).toBe(false);
+    // approval gate title: maxLength 200
+    expect(
+      validateFlowDefinition({
+        name: "f",
+        steps: [
+          { key: "work", agent: "a", skills: ["s@1"] },
+          { key: "gate", type: "approval_gate", title: "T".repeat(201) },
+        ],
+      }).ok,
+    ).toBe(false);
+  });
+
+  it("accepts free-text fields at their maximum length", () => {
+    const result = validateFlowDefinition({
+      name: "f",
+      steps: [{ key: "s", agent: "a", skills: ["s@1"], instructions: "x".repeat(4000) }],
+    });
+    expect(result.ok).toBe(true);
+  });
+});
+
 describe("isApprovalGate", () => {
   it("discriminates gates from agent steps", () => {
     const ok = validateFlowDefinition(VALID);

--- a/packages/shared/src/flow-definition.ts
+++ b/packages/shared/src/flow-definition.ts
@@ -24,10 +24,12 @@ export const SkillRef = Type.String({
 
 export const AgentStep = Type.Object(
   {
-    key: Type.String({ pattern: "^[a-z0-9][a-z0-9_-]*$" }),
+    key: Type.String({ pattern: "^[a-z0-9][a-z0-9_-]*$", maxLength: 200 }),
     agent: Type.String({ minLength: 1 }),
-    skills: Type.Array(SkillRef, { minItems: 1 }),
-    instructions: Type.Optional(Type.String()),
+    // Bound skills per step: each ref is one ungranted-skill check at run time,
+    // so an oversized list amplifies into serial DB work (see steps maxItems).
+    skills: Type.Array(SkillRef, { minItems: 1, maxItems: 50 }),
+    instructions: Type.Optional(Type.String({ maxLength: 4000 })),
     retries: Type.Optional(
       Type.Object(
         {
@@ -51,7 +53,7 @@ export const ApprovalGateApprovals = Type.Object(
   {
     min_approvals: Type.Optional(Type.Integer({ minimum: 1 })),
     approver_emails: Type.Optional(
-      Type.Array(Type.String({ pattern: EMAIL_PATTERN }), { minItems: 1 }),
+      Type.Array(Type.String({ pattern: EMAIL_PATTERN }), { minItems: 1, maxItems: 100 }),
     ),
     forbid_requester: Type.Optional(Type.Boolean()),
   },
@@ -60,9 +62,9 @@ export const ApprovalGateApprovals = Type.Object(
 
 export const ApprovalGateStep = Type.Object(
   {
-    key: Type.String({ pattern: "^[a-z0-9][a-z0-9_-]*$" }),
+    key: Type.String({ pattern: "^[a-z0-9][a-z0-9_-]*$", maxLength: 200 }),
     type: Type.Literal("approval_gate"),
-    title: Type.String({ minLength: 1 }),
+    title: Type.String({ minLength: 1, maxLength: 200 }),
     // Optional n-of-m named approvals. Defining this object switches the gate
     // into identity mode: forbid_requester defaults to TRUE, and decisions
     // must come from authenticated users (fail closed).
@@ -73,8 +75,15 @@ export const ApprovalGateStep = Type.Object(
 
 export const FlowDefinitionSchema = Type.Object(
   {
-    name: Type.String({ pattern: "^[a-z0-9][a-z0-9-]*$" }),
-    steps: Type.Array(Type.Union([ApprovalGateStep, AgentStep]), { minItems: 1 }),
+    name: Type.String({ pattern: "^[a-z0-9][a-z0-9-]*$", maxLength: 200 }),
+    // Bound the step count: each step is published, scheduled, and audited
+    // serially, so an oversized definition would amplify into tens of thousands
+    // of serial DB queries from a single POST /flows. 200 is well above any real
+    // sequential flow while still capping the blast radius.
+    steps: Type.Array(Type.Union([ApprovalGateStep, AgentStep]), {
+      minItems: 1,
+      maxItems: 200,
+    }),
   },
   { additionalProperties: false },
 );


### PR DESCRIPTION
Adds maxItems (steps 200, skills 50, approver_emails 100) + maxLength (name/key/title 200, instructions 4000) to the flow grammar so a single oversized POST /flows can't amplify into tens of thousands of serial DB queries. Adversarial over-limit cases rejected, at-ceiling cases pass (22 shared tests). From the internal audit; verified locally (tsc/eslint/vitest).