### PR TITLE
fix(api): mask gate approver_emails from non-admin flow reads

### DIFF
--- a/packages/server/src/api/admin-routes.ts
+++ b/packages/server/src/api/admin-routes.ts
@@ -1,4 +1,4 @@
-import { SKILL_REF_PATTERN } from "@makerchecker/shared";
+import { isApprovalGate, SKILL_REF_PATTERN, type FlowDefinition } from "@makerchecker/shared";
 import { Type, type Static } from "@sinclair/typebox";
 import { Ajv } from "ajv";
 import type { FastifyInstance, FastifyReply, FastifyRequest } from "fastify";
@@ -242,6 +242,36 @@ export async function requireAdmin(req: FastifyRequest, reply: FastifyReply): Pr
   if (authDisabled()) return;
   if (req.authUser?.is_admin === true) return;
   await reply.status(403).send({ error: "admin privileges required" });
+}
+
+/**
+ * Read-path masking of a stored flow definition for non-privileged callers.
+ *
+ * A gate's `approvals.approver_emails` is the list of NAMED human approver
+ * identities — PII that no non-admin needs to read a flow's structure. This
+ * shapes the RESPONSE only: it deep-clones the definition and drops the
+ * `approver_emails` key from every approval gate that carries one, leaving the
+ * gate's title and the rest of its identity config (min_approvals,
+ * forbid_requester) intact. The stored row and every enforcement path keep the
+ * full list — only the bytes returned to a non-admin change.
+ *
+ * We DROP the key rather than emit a placeholder so the response shape exactly
+ * matches an open-pool gate (one that never named approvers): a non-admin
+ * cannot distinguish "no list" from "list withheld", which is the point — the
+ * identities, and even the count of them, stay private.
+ */
+function maskApproverEmails(definition: unknown): unknown {
+  if (typeof definition !== "object" || definition === null) return definition;
+  const def = definition as FlowDefinition;
+  if (!Array.isArray(def.steps)) return definition;
+  return {
+    ...def,
+    steps: def.steps.map((step) => {
+      if (!isApprovalGate(step) || !step.approvals?.approver_emails) return step;
+      const { approver_emails: _omitted, ...approvals } = step.approvals;
+      return { ...step, approvals };
+    }),
+  };
 }
 
 function pgErrorCode(err: unknown): string | undefined {
@@ -954,7 +984,18 @@ export function registerAdminRoutes(app: FastifyInstance, ctx: EngineContext): v
            FROM flow_versions WHERE flow_id = $1 ORDER BY version DESC`,
         [flow.rows[0].id],
       );
-      return { flow: flow.rows[0], versions: versions.rows };
+      // A gate's approver_emails are named human identities (PII). Admins (and
+      // auth-disabled mode) get the full definition; every other caller gets it
+      // with that list stripped from each gate. Read-path shaping only — the
+      // stored definition and all enforcement paths keep the full list.
+      const privileged = authDisabled() || req.authUser?.is_admin === true;
+      const rows = privileged
+        ? versions.rows
+        : versions.rows.map((v: Record<string, unknown>) => ({
+            ...v,
+            definition: maskApproverEmails(v.definition),
+          }));
+      return { flow: flow.rows[0], versions: rows };
     },
   );
 

--- a/packages/server/src/api/authorization.integration.test.ts
+++ b/packages/server/src/api/authorization.integration.test.ts
@@ -583,6 +583,69 @@ describe("object-level read scoping", () => {
     expect(asMallory.recentRuns).toEqual([]); // run instances are not
   });
 
+  it("masks gate approver_emails (named human PII) from a non-admin on GET /flows/:name", async () => {
+    // named-gate's definition carries approver_emails = [alice, bob] (set up in
+    // the top-level beforeAll). Those are named human identities (PII) that no
+    // non-admin needs to read a flow's structure.
+    const emails = ["alice@bank.example", "bob@bank.example"];
+
+    // Non-admin: the gate's structure/title survives but the email list is gone.
+    const asMallory = (
+      await app.inject({ method: "GET", url: "/api/flows/named-gate", headers: users.mallory!.auth })
+    ).json();
+    const maskedGate = (asMallory.versions[0].definition.steps as Array<Record<string, unknown>>).find(
+      (s) => s.key === "gate",
+    )!;
+    expect(maskedGate.title).toBe("Gate of named-gate"); // structure intact
+    expect((maskedGate.approvals as Record<string, unknown>).min_approvals).toBe(1); // config intact
+    expect((maskedGate.approvals as Record<string, unknown>).approver_emails).toBeUndefined();
+    // No approver email leaks anywhere in the response (not even the count).
+    for (const email of emails) expect(JSON.stringify(asMallory)).not.toContain(email);
+
+    // The run's own requester is still a non-admin: same masking applies.
+    const asRequester = (
+      await app.inject({ method: "GET", url: "/api/flows/named-gate", headers: users.requester!.auth })
+    ).json();
+    for (const email of emails) expect(JSON.stringify(asRequester)).not.toContain(email);
+
+    // Admin: full definition, approver_emails present and exact.
+    const asAdmin = (
+      await app.inject({ method: "GET", url: "/api/flows/named-gate", headers: users.admin!.auth })
+    ).json();
+    const adminGate = (asAdmin.versions[0].definition.steps as Array<Record<string, unknown>>).find(
+      (s) => s.key === "gate",
+    )!;
+    expect((adminGate.approvals as Record<string, unknown>).approver_emails).toEqual(emails);
+
+    // Auth-disabled mode is an operator opt-out: the full list is returned.
+    process.env.MAKERCHECKER_AUTH_DISABLED = "1";
+    try {
+      const asOpen = (
+        await app.inject({ method: "GET", url: "/api/flows/named-gate" })
+      ).json();
+      const openGate = (asOpen.versions[0].definition.steps as Array<Record<string, unknown>>).find(
+        (s) => s.key === "gate",
+      )!;
+      expect((openGate.approvals as Record<string, unknown>).approver_emails).toEqual(emails);
+    } finally {
+      delete process.env.MAKERCHECKER_AUTH_DISABLED;
+    }
+  });
+
+  it("does not change the STORED definition: masking is read-path only", async () => {
+    // The at-rest row keeps the full approver list; only the response was shaped.
+    const { rows } = await db.pool.query<{ definition: { steps: Array<Record<string, unknown>> } }>(
+      `SELECT fv.definition FROM flow_versions fv
+         JOIN flows f ON f.id = fv.flow_id
+        WHERE f.name = 'named-gate' ORDER BY fv.version DESC LIMIT 1`,
+    );
+    const gate = rows[0]!.definition.steps.find((s) => s.key === "gate")!;
+    expect((gate.approvals as Record<string, unknown>).approver_emails).toEqual([
+      "alice@bank.example",
+      "bob@bank.example",
+    ]);
+  });
+
   it("the audit chain still verifies after every adversarial path", async () => {
     expect((await verifyChain(db.pool)).ok).toBe(true);
   });


### PR DESCRIPTION
GET /flows/:name returned each version's full definition verbatim, including approvals.approver_emails (named-approver PII). Now masked for non-admins (admins/auth-disabled keep the full view); response-shaping only, enforcement untouched. (GET /flows returns summary columns, no definition.) Test asserts non-admin can't see emails, admin can, and the stored definition is unchanged (40 authz tests). Verified locally.