### PR TITLE
test(engine): SoD-revocation e2e + in-loop enforcement-pin gaps

### DIFF
--- a/packages/server/src/engine/engine.integration.test.ts
+++ b/packages/server/src/engine/engine.integration.test.ts
@@ -618,6 +618,66 @@ describe("M3 — segregation of duties", () => {
     );
     expect(rows.every((r) => r.status === "completed")).toBe(true);
   });
+
+  // ADVERSARIAL: revoking an SoD constraint must unblock FUTURE runs without
+  // rewriting history — the original violation's audit event survives. A control
+  // that, once lifted, also erased the evidence that it ever fired would be a
+  // forgery primitive; revocation is forward-only, the chain is append-only.
+  it("revoking a constraint unblocks new runs but never erases the original violation", async () => {
+    await seedAgent("recon-preparer-rev", "preparer-rev-role");
+    await seedAgent("recon-approver-rev", "approver-rev-role");
+    await seedSkill("prepare-recon-rev@1", async (i) => ({ ...i, prepared: true }));
+    await seedSkill("approve-recon-rev@1", async (i) => ({ ...i, approved: true }));
+    await grant("recon-preparer-rev", "prepare-recon-rev@1");
+    await grant("recon-approver-rev", "approve-recon-rev@1");
+
+    await db.pool.query(
+      `INSERT INTO sod_constraints (role_a_id, role_b_id, description)
+       SELECT least(p.id, a.id), greatest(p.id, a.id), 'maker-checker: prepare vs approve (revocable)'
+         FROM roles p, roles a
+        WHERE p.name = 'preparer-rev-role' AND a.name = 'approver-rev-role'`,
+    );
+
+    // A cross-role flow: the approver acts first, then the preparer — the SoD
+    // pair binds, so the preparer's step must be blocked while active.
+    const { flowVersionId: crossFlow } = await publishFlowVersion(db.pool, {
+      definition: {
+        name: "revocable-cross-role-flow",
+        steps: [
+          { key: "approve_first", agent: "recon-approver-rev", skills: ["approve-recon-rev@1"] },
+          { key: "then_prepare", agent: "recon-preparer-rev", skills: ["prepare-recon-rev@1"] },
+        ],
+      },
+      actor: USER,
+    });
+
+    // 1. With the constraint ACTIVE, the cross-role run is blocked.
+    const blockedRun = await startRun(ctx, { flowVersionId: crossFlow, triggeredBy: USER });
+    expect(await waitForRunStatus(blockedRun, ["failed"])).toBe("failed");
+    expect(await eventTypes(blockedRun)).toContain("enforcement.sod_violation");
+
+    // 2. Revoke (never delete) the constraint.
+    const revoked = await db.pool.query(
+      `UPDATE sod_constraints SET revoked_at = now()
+        WHERE description = 'maker-checker: prepare vs approve (revocable)' AND revoked_at IS NULL`,
+    );
+    expect(revoked.rowCount).toBe(1);
+
+    // 3. A NEW cross-role run now COMPLETES — revocation is forward-effective.
+    const allowedRun = await startRun(ctx, { flowVersionId: crossFlow, triggeredBy: USER });
+    expect(await waitForRunStatus(allowedRun, ["completed", "failed"])).toBe("completed");
+    expect(await eventTypes(allowedRun)).not.toContain("enforcement.sod_violation");
+
+    // 4. The ORIGINAL run's violation event is still on the chain — revocation
+    //    changed policy going forward, it did NOT rewrite what already happened.
+    const { rows } = await db.pool.query(
+      "SELECT payload FROM audit_events WHERE run_id = $1 AND event_type = 'enforcement.sod_violation'",
+      [blockedRun],
+    );
+    expect(rows).toHaveLength(1);
+    expect(rows[0]!.payload).toMatchObject({ code: "sod_violation" });
+    expect((await verifyChain(db.pool)).ok).toBe(true);
+  });
 });
 
 describe("M3 — high-risk skills require gates", () => {

--- a/packages/server/src/engine/llm-executor.integration.test.ts
+++ b/packages/server/src/engine/llm-executor.integration.test.ts
@@ -272,6 +272,82 @@ describe("LLMExecutor — tool-use loop", () => {
       /no LLM provider registered/,
     );
   });
+
+  // ADVERSARIAL: enforcement filters the permitted skill set ONCE, upstream of
+  // the loop; the loop then PINS that set for the whole step (allow-until-step-
+  // end). So a grant revoked mid-step — even the running step's own role
+  // revoking its grant for a not-yet-called tool — does NOT shrink the pinned
+  // set: the second invocation still runs. This is intentional and documented:
+  // the loop must not re-enforce grants between tool calls (a step that began
+  // authorized completes deterministically; the revocation governs the NEXT
+  // run). The guarantee that protects against ungranted execution lives at
+  // scheduling + invocation enforcement, not inside the model's tool loop.
+  it("pins the permitted tools for the step — a mid-loop grant revoke does not re-enforce", async () => {
+    const runId = "10000000-0000-0000-0000-000000000005";
+
+    // Grant both skills to the executor's role. The FIRST skill's fn revokes
+    // this very role's grant for the SECOND skill while the step is mid-flight.
+    await seedSkill("revoke-self@1", {
+      fn: async () => {
+        await db.pool.query(
+          `UPDATE role_skill_grants SET revoked_at = now()
+            WHERE role_id = $1
+              AND skill_id = (SELECT id FROM skills WHERE name = 'second-tool' AND version = 1)
+              AND revoked_at IS NULL`,
+          [META.roleId],
+        );
+        return { revokedSecondGrant: true };
+      },
+    });
+    await seedSkill("second-tool@1", { fn: async () => ({ ran: true }) });
+    await db.pool.query(
+      `INSERT INTO role_skill_grants (role_id, skill_id)
+       SELECT $1, id FROM skills WHERE name IN ('revoke-self', 'second-tool') AND version = 1`,
+      [META.roleId],
+    );
+
+    // Two tool calls back to back, then a final text turn. The grant for the
+    // second tool is gone by the time it is invoked — but the loop pinned it.
+    const provider = new MockProvider().queue(
+      toolCall(toolNameForRef("revoke-self@1"), {}, "call_revoke"),
+      toolCall(toolNameForRef("second-tool@1"), {}, "call_second"),
+      text("Both tools ran."),
+    );
+
+    const output = await makeExecutor(provider).execute(
+      stepReq(["revoke-self@1", "second-tool@1"], {}, runId),
+    );
+    // The loop completed normally — the second invocation was NOT re-enforced.
+    expect(output).toEqual({ text: "Both tools ran.", iterations: 3 });
+
+    // The grant really is revoked now (so any FUTURE step would be blocked
+    // upstream), proving the revoke fired mid-step — yet this step still ran it.
+    const activeGrant = await db.pool.query(
+      `SELECT 1 FROM role_skill_grants
+        WHERE role_id = $1
+          AND skill_id = (SELECT id FROM skills WHERE name = 'second-tool' AND version = 1)
+          AND revoked_at IS NULL`,
+      [META.roleId],
+    );
+    expect(activeGrant.rowCount).toBe(0);
+
+    // Both skills were invoked and audited; the second produced its real output
+    // (not an enforcement error fed back to the model).
+    const events = await auditEvents(runId);
+    expect(events.map((e) => e.event_type)).toEqual([
+      "llm.call",
+      "skill.invoked",
+      "llm.call",
+      "skill.invoked",
+      "llm.call",
+    ]);
+    const invoked = events.filter((e) => e.event_type === "skill.invoked");
+    expect(invoked[0]!.payload).toMatchObject({ skillRef: "revoke-self@1" });
+    expect(invoked[1]!.payload).toMatchObject({
+      skillRef: "second-tool@1",
+      output: { ran: true },
+    });
+  });
 });
 
 describe("SkillInvoker — http and mcp dispatch", () => {


### PR DESCRIPTION
Two adversarial tests (no source changes) the audit flagged: (A) revoking an SoD constraint unblocks new runs but the original run's enforcement.sod_violation event still exists + chain verifies; (B) a mid-loop grant revoke does NOT re-enforce between tool calls (pins allow-until-step-end). 51 engine tests pass. Verified locally.