### PR TITLE
feat(connector): typed Claude Agent SDK connector

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,6 @@ docs/positioning/
 
 # Local-only docker override (recording/dev aid)
 docker-compose.override.yml
+
+# Local agent tooling / transient worktrees
+.claude/

--- a/LICENSING.md
+++ b/LICENSING.md
@@ -8,7 +8,7 @@ license** available for organizations whose policies preclude AGPL-3.0.
 | Component | Package(s) | License |
 | --- | --- | --- |
 | Control plane | `packages/server`, `packages/web`, `packages/shared` | **AGPL-3.0-only** ([LICENSE](LICENSE)) |
-| Integration layer | `packages/sdk`, `packages/connector-langchain`, `examples/` | **Apache-2.0** ([sdk](packages/sdk/LICENSE), [connector](packages/connector-langchain/LICENSE), [examples](examples/LICENSE)) |
+| Integration layer | `packages/sdk`, `packages/connector-langchain`, `packages/connector-claude-agent`, `examples/` | **Apache-2.0** ([sdk](packages/sdk/LICENSE), [langchain](packages/connector-langchain/LICENSE), [claude-agent](packages/connector-claude-agent/LICENSE), [examples](examples/LICENSE)) |
 
 **Why AGPL for the core.** The control plane is the part an auditor relies on:
 the enforcement engine and the tamper-evident audit chain. AGPL-3.0 keeps it

--- a/README.md
+++ b/README.md
@@ -144,7 +144,7 @@ On April 17, 2026 the Federal Reserve replaced SR 11-7 with SR 26-2, which expli
 - flows with approval gates, retries, timeouts, and a crash-recovery watchdog
 - n-of-m named approvals: quorums, named approver lists, requester self-approval forbidden by default (fail closed)
 - enforced role limits & budgets: per-skill invocation caps, fail-closed amount ceilings, run-level invocation and token budgets
-- proxy sessions wrapping LangGraph/CrewAI/Claude Agent SDK agents with grant checks, SoD, and the audit trail, no migration into the flow engine; a typed [LangChain connector](packages/connector-langchain) ([demo](examples/connectors/langchain/README.md)) plus generic [middleware recipes](examples/middleware/README.md)
+- proxy sessions wrapping LangGraph/CrewAI/Claude Agent SDK agents with grant checks, SoD, and the audit trail, no migration into the flow engine; typed connectors for [LangChain](packages/connector-langchain) ([demo](examples/connectors/langchain/README.md)) and the [Claude Agent SDK](packages/connector-claude-agent), plus generic [middleware recipes](examples/middleware/README.md)
 - hash-chained audit log with Ed25519-signed export bundles and a CLI verifier
 - evidence packs: `makerchecker audit report --run <id>` renders a self-contained HTML run report with chain verification; `makerchecker audit access-review` renders the role/grant/SoD review (also JSON at `/api/reports/access-review`)
 - cron triggers scheduled at boot (runs start as `system/cron` from the latest published version)
@@ -157,7 +157,7 @@ On April 17, 2026 the Federal Reserve replaced SR 11-7 with SR 26-2, which expli
 ## License
 
 - `packages/server`, `packages/web`, `packages/shared`: **AGPL-3.0** ([LICENSE](LICENSE))
-- `packages/sdk`, `packages/connector-langchain`, and `examples/`: **Apache-2.0** ([packages/sdk/LICENSE](packages/sdk/LICENSE), [packages/connector-langchain/LICENSE](packages/connector-langchain/LICENSE), [examples/LICENSE](examples/LICENSE)), code you embed in your own systems never carries AGPL obligations
+- `packages/sdk`, `packages/connector-langchain`, `packages/connector-claude-agent`, and `examples/`: **Apache-2.0** ([packages/sdk/LICENSE](packages/sdk/LICENSE), [packages/connector-langchain/LICENSE](packages/connector-langchain/LICENSE), [packages/connector-claude-agent/LICENSE](packages/connector-claude-agent/LICENSE), [examples/LICENSE](examples/LICENSE)), code you embed in your own systems never carries AGPL obligations
 - A **commercial license** (no copyleft obligation) is available for organizations whose policies preclude AGPL-3.0: hello@makerchecker.ai
 
 Licensing rationale and the commercial/CLA model: [LICENSING.md](LICENSING.md). The audit chain is specified for independent offline verification ([audit spec](docs/audit-spec.md)); security reports are welcome ([SECURITY.md](SECURITY.md)).

--- a/packages/connector-claude-agent/LICENSE
+++ b/packages/connector-claude-agent/LICENSE
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/packages/connector-claude-agent/README.md
+++ b/packages/connector-claude-agent/README.md
@@ -1,0 +1,36 @@
+# @makerchecker/connector-claude-agent
+
+Govern [Claude Agent SDK](https://github.com/anthropics/claude-agent-sdk-typescript)
+custom tools through MakerChecker. Wrap, don't migrate: each tool keeps executing
+inside the Claude Agent SDK; MakerChecker becomes the deny-by-default
+authorization checkpoint and the hash-chained evidentiary record.
+
+`governClaudeTool` returns a normal `SdkMcpToolDefinition` (same `name`,
+`description`, and `inputSchema` as the underlying tool), so it drops straight
+into `createSdkMcpServer`. Its handler runs `proxy.check` first (a deny throws
+`GovernanceDeniedError` before the tool body runs), then the tool, then
+`proxy.record` with the output (or the error, which is rethrown).
+
+```ts
+import { createSdkMcpServer } from "@anthropic-ai/claude-agent-sdk";
+import { createClient } from "@makerchecker/sdk";
+import { governClaudeTool } from "@makerchecker/connector-claude-agent";
+import { z } from "zod";
+
+const client = createClient({ baseUrl: "http://localhost:3000", apiKey: "mk_..." });
+const { session } = await client.proxy.openSession({ label: "claude-run" });
+
+const ingest = governClaudeTool(
+  client,
+  { sessionId: session.id, agentName: "recon-preparer", skillRef: "csv-ingest@1" },
+  "csv_ingest",
+  "Ingest the statement CSVs",
+  { statementPath: z.string() },
+  async (args) => ({ content: [{ type: "text", text: await readCsv(args) }] }),
+);
+
+const server = createSdkMcpServer({ name: "governed-tools", tools: [ingest] });
+```
+
+`@anthropic-ai/claude-agent-sdk` is a peer dependency. Apache-2.0: embedding this
+connector in your own systems never carries AGPL obligations.

--- a/packages/connector-claude-agent/package.json
+++ b/packages/connector-claude-agent/package.json
@@ -1,0 +1,33 @@
+{
+  "name": "@makerchecker/connector-claude-agent",
+  "version": "1.0.0",
+  "license": "Apache-2.0",
+  "private": true,
+  "type": "module",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
+    }
+  },
+  "scripts": {
+    "build": "tsc -p tsconfig.json",
+    "typecheck": "tsc -p tsconfig.json --noEmit",
+    "lint": "eslint src",
+    "test": "vitest run --coverage"
+  },
+  "dependencies": {
+    "@makerchecker/sdk": "workspace:*"
+  },
+  "peerDependencies": {
+    "@anthropic-ai/claude-agent-sdk": "^0.3.0"
+  },
+  "devDependencies": {
+    "@anthropic-ai/claude-agent-sdk": "^0.3.0",
+    "@types/node": "^22.10.7",
+    "@vitest/coverage-v8": "^3.0.4",
+    "typescript": "^5.7.3",
+    "vitest": "^3.0.4",
+    "zod": "^4.4.3"
+  }
+}

--- a/packages/connector-claude-agent/src/index.test.ts
+++ b/packages/connector-claude-agent/src/index.test.ts
@@ -1,0 +1,104 @@
+import { describe, expect, it, vi } from "vitest";
+import { z } from "zod";
+
+import type { Client } from "@makerchecker/sdk";
+
+import { governClaudeTool, GovernanceDeniedError } from "./index.js";
+
+/**
+ * Minimal mock of the MakerChecker client's proxy surface. No server is
+ * involved: `check` is programmed to allow or deny, and `record` is a spy we
+ * assert against. Mirrors the connector-langchain test.
+ */
+function mockClient(opts: {
+  check: () => Awaited<ReturnType<Client["proxy"]["check"]>>;
+}): {
+  client: Client;
+  check: ReturnType<typeof vi.fn>;
+  record: ReturnType<typeof vi.fn>;
+} {
+  const check = vi.fn(async () => opts.check());
+  const record = vi.fn(async () => ({ ok: true }));
+  const client = { proxy: { check, record } } as unknown as Client;
+  return { client, check, record };
+}
+
+const CTX = { sessionId: "ps-1", agentName: "recon-preparer", skillRef: "csv-ingest@1" };
+const shape = { n: z.number() };
+
+function okResult(text: string) {
+  return { content: [{ type: "text" as const, text }] };
+}
+
+describe("governClaudeTool", () => {
+  it("preserves the name, description, and inputSchema on the governed tool", () => {
+    const { client } = mockClient({ check: () => ({ allowed: true, checkId: "ck" }) });
+    const t = governClaudeTool(client, CTX, "ingest", "ingest the CSVs", shape, async (a) =>
+      okResult(String(a.n)),
+    );
+    expect(t.name).toBe("ingest");
+    expect(t.description).toBe("ingest the CSVs");
+    expect(t.inputSchema).toBe(shape);
+  });
+
+  it("granted: checks, runs the handler, records the output, returns it", async () => {
+    const { client, check, record } = mockClient({
+      check: () => ({ allowed: true, checkId: "ck-1" }),
+    });
+    const handler = vi.fn(async (a: { n: number }) => okResult(String(a.n * 2)));
+    const t = governClaudeTool(client, CTX, "double", "doubles", shape, handler);
+
+    const out = await t.handler({ n: 21 }, {});
+    expect(out).toEqual(okResult("42"));
+    expect(check).toHaveBeenCalledWith("ps-1", {
+      agentName: "recon-preparer",
+      skillRef: "csv-ingest@1",
+      input: { n: 21 },
+    });
+    expect(handler).toHaveBeenCalledOnce();
+    expect(record).toHaveBeenCalledWith("ps-1", { checkId: "ck-1", output: okResult("42") });
+  });
+
+  it("denied: throws GovernanceDeniedError and NEVER invokes the handler", async () => {
+    const { client, check, record } = mockClient({
+      check: () => ({ allowed: false, code: "skill_not_granted", reason: "no grant" }),
+    });
+    const handler = vi.fn(async () => okResult("must not run"));
+    const t = governClaudeTool(client, CTX, "blocked", "b", shape, handler);
+
+    const err = await t.handler({ n: 1 }, {}).catch((e: unknown) => e);
+    expect(err).toBeInstanceOf(GovernanceDeniedError);
+    expect((err as GovernanceDeniedError).code).toBe("skill_not_granted");
+    expect((err as GovernanceDeniedError).reason).toBe("no grant");
+    expect(handler).not.toHaveBeenCalled();
+    expect(check).toHaveBeenCalledOnce();
+    expect(record).not.toHaveBeenCalled();
+  });
+
+  it("handler throw: records the error, then rethrows the original", async () => {
+    const { client, record } = mockClient({ check: () => ({ allowed: true, checkId: "ck-9" }) });
+    const boom = new Error("downstream exploded");
+    const t = governClaudeTool(client, CTX, "fails", "f", shape, async () => {
+      throw boom;
+    });
+
+    await expect(t.handler({ n: 1 }, {})).rejects.toBe(boom);
+    expect(record).toHaveBeenCalledWith("ps-1", {
+      checkId: "ck-9",
+      error: { message: "downstream exploded" },
+    });
+  });
+
+  it("non-Error throw values are stringified into the recorded error", async () => {
+    const { client, record } = mockClient({ check: () => ({ allowed: true, checkId: "ck-2" }) });
+    const t = governClaudeTool(client, CTX, "weird", "throws a string", shape, async () => {
+      throw "string failure";
+    });
+
+    await expect(t.handler({ n: 1 }, {})).rejects.toBe("string failure");
+    expect(record).toHaveBeenCalledWith("ps-1", {
+      checkId: "ck-2",
+      error: { message: "string failure" },
+    });
+  });
+});

--- a/packages/connector-claude-agent/src/index.ts
+++ b/packages/connector-claude-agent/src/index.ts
@@ -1,0 +1,121 @@
+/**
+ * @makerchecker/connector-claude-agent — wrap, don't migrate.
+ *
+ * A developer who already has Claude Agent SDK custom tools governs them through
+ * MakerChecker with a thin wrapper. Each tool keeps executing inside the Claude
+ * Agent SDK; MakerChecker becomes the deny-by-default authorization checkpoint
+ * and the hash-chained evidentiary record.
+ *
+ * `governClaudeTool` builds an SDK tool (via `tool(...)`) whose handler:
+ *   1. calls `client.proxy.check` — a deny throws `GovernanceDeniedError`
+ *      BEFORE the underlying handler ever runs (deny by default, fail closed);
+ *   2. runs the original handler;
+ *   3. calls `client.proxy.record` with the output — or, if the handler throws,
+ *      records the error and rethrows the original.
+ *
+ * The result is a normal `SdkMcpToolDefinition`, so it drops straight into
+ * `createSdkMcpServer({ name, tools: [...] })` and the agent is unchanged:
+ *
+ * ```ts
+ * import { createSdkMcpServer } from "@anthropic-ai/claude-agent-sdk";
+ * import { governClaudeTool } from "@makerchecker/connector-claude-agent";
+ *
+ * const ingest = governClaudeTool(
+ *   client,
+ *   { sessionId: session.id, agentName: "recon-preparer", skillRef: "csv-ingest@1" },
+ *   "csv_ingest",
+ *   "Ingest statement CSVs",
+ *   { statementPath: z.string() },
+ *   async (args) => ({ content: [{ type: "text", text: await readCsv(args) }] }),
+ * );
+ * const server = createSdkMcpServer({ name: "governed-tools", tools: [ingest] });
+ * ```
+ */
+
+import {
+  tool,
+  type AnyZodRawShape,
+  type InferShape,
+  type SdkMcpToolDefinition,
+} from "@anthropic-ai/claude-agent-sdk";
+import { type Client, GovernanceDeniedError, type ProxyRecordInput } from "@makerchecker/sdk";
+
+export { GovernanceDeniedError } from "@makerchecker/sdk";
+
+/**
+ * The MCP tool result a Claude Agent SDK tool handler returns. Derived from the
+ * SDK's exported tool-definition type (the SDK does not re-export the underlying
+ * CallToolResult), so the connector needs no direct @modelcontextprotocol/sdk dep.
+ */
+type ToolResult = Awaited<ReturnType<SdkMcpToolDefinition["handler"]>>;
+
+/**
+ * Identifies the governed call to MakerChecker:
+ * - `sessionId`  — an open proxy session (`client.proxy.openSession`);
+ * - `agentName`  — the registered agent whose role grants are evaluated;
+ * - `skillRef`   — the `name@version` of the skill this tool maps to.
+ */
+export interface GovernContext {
+  sessionId: string;
+  agentName: string;
+  skillRef: string;
+}
+
+/**
+ * Coerce a thrown value into the shape `client.proxy.record` accepts as
+ * `error`. Mirrors the SDK's `governedTool` so the audit record is identical
+ * whether the throw was an `Error` or a bare value.
+ */
+function toRecordedError(err: unknown): NonNullable<ProxyRecordInput["error"]> {
+  return { message: err instanceof Error ? err.message : String(err) };
+}
+
+/** True for plain object inputs that the proxy `check` can record as `input`. */
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+/**
+ * Wrap a Claude Agent SDK custom tool so every invocation passes through
+ * MakerChecker. The returned `SdkMcpToolDefinition` preserves the original
+ * `name`, `description`, and `inputSchema`, so the agent's tool spec is
+ * identical to the ungoverned tool. Behaviourally, the handler is governed:
+ *
+ *   check (deny -> throw, handler never runs) -> run -> record output
+ *   handler throws -> record error -> rethrow original
+ *
+ * @throws {GovernanceDeniedError} when MakerChecker denies the call.
+ */
+export function governClaudeTool<Schema extends AnyZodRawShape>(
+  client: Client,
+  context: GovernContext,
+  name: string,
+  description: string,
+  inputSchema: Schema,
+  handler: (args: InferShape<Schema>, extra: unknown) => Promise<ToolResult>,
+): SdkMcpToolDefinition<Schema> {
+  const { sessionId, agentName, skillRef } = context;
+
+  return tool(name, description, inputSchema, async (args, extra) => {
+    const check = await client.proxy.check(sessionId, {
+      agentName,
+      skillRef,
+      ...(isRecord(args) ? { input: args } : {}),
+    });
+    if (!check.allowed) {
+      // Fail closed: the underlying handler is NEVER invoked on a deny.
+      throw new GovernanceDeniedError(check.code, check.reason);
+    }
+    try {
+      const output = await handler(args, extra);
+      await client.proxy.record(sessionId, { checkId: check.checkId, output });
+      return output;
+    } catch (err) {
+      await client.proxy.record(sessionId, {
+        checkId: check.checkId,
+        error: toRecordedError(err),
+      });
+      throw err;
+    }
+  });
+}

--- a/packages/connector-claude-agent/tsconfig.json
+++ b/packages/connector-claude-agent/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src"
+  },
+  "include": ["src"],
+  "exclude": ["src/**/*.test.ts"]
+}

--- a/packages/connector-claude-agent/vitest.config.ts
+++ b/packages/connector-claude-agent/vitest.config.ts
@@ -1,0 +1,17 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    coverage: {
+      provider: "v8",
+      include: ["src/**/*.ts"],
+      exclude: ["src/**/*.test.ts"],
+      thresholds: {
+        lines: 90,
+        functions: 90,
+        branches: 90,
+        statements: 90,
+      },
+    },
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -24,6 +24,31 @@ importers:
         specifier: ^8.20.0
         version: 8.61.0(eslint@9.39.4(jiti@1.21.7))(typescript@5.9.3)
 
+  packages/connector-claude-agent:
+    dependencies:
+      '@makerchecker/sdk':
+        specifier: workspace:*
+        version: link:../sdk
+    devDependencies:
+      '@anthropic-ai/claude-agent-sdk':
+        specifier: ^0.3.0
+        version: 0.3.177(@anthropic-ai/sdk@0.104.1(zod@4.4.3))(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.4.3))(zod@4.4.3)
+      '@types/node':
+        specifier: ^22.10.7
+        version: 22.19.21
+      '@vitest/coverage-v8':
+        specifier: ^3.0.4
+        version: 3.2.6(vitest@3.2.6(@types/debug@4.1.13)(@types/node@22.19.21)(happy-dom@16.8.1)(jiti@1.21.7)(yaml@2.9.0))
+      typescript:
+        specifier: ^5.7.3
+        version: 5.9.3
+      vitest:
+        specifier: ^3.0.4
+        version: 3.2.6(@types/debug@4.1.13)(@types/node@22.19.21)(happy-dom@16.8.1)(jiti@1.21.7)(yaml@2.9.0)
+      zod:
+        specifier: ^4.4.3
+        version: 4.4.3
+
   packages/connector-langchain:
     dependencies:
       '@makerchecker/sdk':
@@ -214,6 +239,54 @@ packages:
   '@ampproject/remapping@2.3.0':
     resolution: {integrity: sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw==}
     engines: {node: '>=6.0.0'}
+
+  '@anthropic-ai/claude-agent-sdk-darwin-arm64@0.3.177':
+    resolution: {integrity: sha512-u9Ty+KPllm2nw0RatdPF0zcPRquNZjVptmyLG0DqduGbgZDLQpfPFMF5hffFIRnVaXhx7+jkUmEdw0jrda0UcA==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@anthropic-ai/claude-agent-sdk-darwin-x64@0.3.177':
+    resolution: {integrity: sha512-ona6Jv54XFwBTqOj3MzLWfKtc2m7Rdh58wOAX9Hnue/6FcWfyeuz/UDcidVTXQ7Xytz//Tb0JJgFtiQjO7FbIA==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@anthropic-ai/claude-agent-sdk-linux-arm64-musl@0.3.177':
+    resolution: {integrity: sha512-v6PMDD3h2erLuTK5S2ZvExqdL3v44OyC70XpKhyqIUnyPaGR9YAMjh//EKdWC+mNvt6mIbRZpaDcHtbASVW8Rw==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@anthropic-ai/claude-agent-sdk-linux-arm64@0.3.177':
+    resolution: {integrity: sha512-wBCbklkaDb483Ab4DUFfmJjZJKXz58YXPv+CiGsyjq1St19mbKEma5KKz3Ya9mlV8aLyh4zmLK2mEHPnF//Ipg==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@anthropic-ai/claude-agent-sdk-linux-x64-musl@0.3.177':
+    resolution: {integrity: sha512-1cdEO06WoEsl1JnnLCPIlg/8x37GtBsTuj65gIpSjdrImNBjgIuMWVyceP4qaXhFjtQgYK1nx3TpaxEFVDOrDg==}
+    cpu: [x64]
+    os: [linux]
+
+  '@anthropic-ai/claude-agent-sdk-linux-x64@0.3.177':
+    resolution: {integrity: sha512-WDP6puwPHscggNAfvIxyUSHSAjfUEkGRfnMXEPBHOqO+qjX2KGxeE13/ih3EVioeBVOUIqPui6VB05vXLa6T9Q==}
+    cpu: [x64]
+    os: [linux]
+
+  '@anthropic-ai/claude-agent-sdk-win32-arm64@0.3.177':
+    resolution: {integrity: sha512-xLgDWnZaYohtFrkgEIkGZdP+rp4sXxAMbbpEvEp0LK1vAYmJam/ztT2yoK6gfI58IbToJq1WGUEX2HVnE65yOg==}
+    cpu: [arm64]
+    os: [win32]
+
+  '@anthropic-ai/claude-agent-sdk-win32-x64@0.3.177':
+    resolution: {integrity: sha512-SIdQLbtF//rYK4KDBNpUPyjyui7NwCFPZ2/3vyW3TR8R8xynkNq3cLis90FnPSgxaSshi38vkJYWh+9kGDB7zg==}
+    cpu: [x64]
+    os: [win32]
+
+  '@anthropic-ai/claude-agent-sdk@0.3.177':
+    resolution: {integrity: sha512-CBzXnzR661q3AlfZzBjmIFQx0cxr36iJV3PExTYmPyGQX32qxtiFQgnxTcF8wB4hcSVf2hnoy/gprVJdkNx7cw==}
+    engines: {node: '>=18.0.0'}
+    peerDependencies:
+      '@anthropic-ai/sdk': '>=0.93.0'
+      '@modelcontextprotocol/sdk': ^1.29.0
+      zod: ^4.0.0
 
   '@anthropic-ai/sdk@0.104.1':
     resolution: {integrity: sha512-gGACa/+IaiXzRRmF96aOhamoBgapKRBiFWbmmTFP8aMkpaEcuStF+Q61bjo4vPxBM7gqWJNZqsngslRdnLHv0Q==}
@@ -2683,6 +2756,45 @@ snapshots:
     dependencies:
       '@jridgewell/gen-mapping': 0.3.13
       '@jridgewell/trace-mapping': 0.3.31
+
+  '@anthropic-ai/claude-agent-sdk-darwin-arm64@0.3.177':
+    optional: true
+
+  '@anthropic-ai/claude-agent-sdk-darwin-x64@0.3.177':
+    optional: true
+
+  '@anthropic-ai/claude-agent-sdk-linux-arm64-musl@0.3.177':
+    optional: true
+
+  '@anthropic-ai/claude-agent-sdk-linux-arm64@0.3.177':
+    optional: true
+
+  '@anthropic-ai/claude-agent-sdk-linux-x64-musl@0.3.177':
+    optional: true
+
+  '@anthropic-ai/claude-agent-sdk-linux-x64@0.3.177':
+    optional: true
+
+  '@anthropic-ai/claude-agent-sdk-win32-arm64@0.3.177':
+    optional: true
+
+  '@anthropic-ai/claude-agent-sdk-win32-x64@0.3.177':
+    optional: true
+
+  '@anthropic-ai/claude-agent-sdk@0.3.177(@anthropic-ai/sdk@0.104.1(zod@4.4.3))(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.4.3))(zod@4.4.3)':
+    dependencies:
+      '@anthropic-ai/sdk': 0.104.1(zod@4.4.3)
+      '@modelcontextprotocol/sdk': 1.29.0(@cfworker/json-schema@4.1.1)(zod@4.4.3)
+      zod: 4.4.3
+    optionalDependencies:
+      '@anthropic-ai/claude-agent-sdk-darwin-arm64': 0.3.177
+      '@anthropic-ai/claude-agent-sdk-darwin-x64': 0.3.177
+      '@anthropic-ai/claude-agent-sdk-linux-arm64': 0.3.177
+      '@anthropic-ai/claude-agent-sdk-linux-arm64-musl': 0.3.177
+      '@anthropic-ai/claude-agent-sdk-linux-x64': 0.3.177
+      '@anthropic-ai/claude-agent-sdk-linux-x64-musl': 0.3.177
+      '@anthropic-ai/claude-agent-sdk-win32-arm64': 0.3.177
+      '@anthropic-ai/claude-agent-sdk-win32-x64': 0.3.177
 
   '@anthropic-ai/sdk@0.104.1(zod@4.4.3)':
     dependencies:


### PR DESCRIPTION
The README markets the Claude Agent SDK as a first-class integration target alongside LangChain, but only LangChain had a typed connector. Adds **@makerchecker/connector-claude-agent** (Apache-2.0), mirroring connector-langchain.

`governClaudeTool(client, ctx, name, description, inputSchema, handler)` wraps the SDK's `tool()` so its handler runs `proxy.check` (a deny throws `GovernanceDeniedError` **before** the tool body runs) -> handler -> `proxy.record` (output, or the error which is rethrown). It returns a normal `SdkMcpToolDefinition`, so it drops straight into `createSdkMcpServer({ tools: [...] })` and the agent is unchanged.

The result type is derived from the SDK's own exported handler type, so the connector needs no direct `@modelcontextprotocol/sdk` dependency; `@anthropic-ai/claude-agent-sdk` is a peer dependency.

Unit tests (allow/deny/throw/non-Error throw): 100% statements, 90.9% branches. Wired into the README integration section + the LICENSING table; LICENSE added. Also gitignores `.claude/` (local agent worktrees).