### PR TITLE
fix(deps): upgrade happy-dom to clear the Critical VM-escape RCE advisory

### DIFF
--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -26,7 +26,7 @@
     "@vitejs/plugin-react": "^4.3.4",
     "@vitest/coverage-v8": "^3.0.4",
     "autoprefixer": "^10.5.0",
-    "happy-dom": "^16.7.2",
+    "happy-dom": "^20.10.3",
     "postcss": "^8.5.15",
     "tailwindcss": "^3",
     "typescript": "^5.7.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -38,13 +38,13 @@ importers:
         version: 22.19.21
       '@vitest/coverage-v8':
         specifier: ^3.0.4
-        version: 3.2.6(vitest@3.2.6(@types/debug@4.1.13)(@types/node@22.19.21)(happy-dom@16.8.1)(jiti@1.21.7)(yaml@2.9.0))
+        version: 3.2.6(vitest@3.2.6(@types/debug@4.1.13)(@types/node@22.19.21)(happy-dom@20.10.3)(jiti@1.21.7)(yaml@2.9.0))
       typescript:
         specifier: ^5.7.3
         version: 5.9.3
       vitest:
         specifier: ^3.0.4
-        version: 3.2.6(@types/debug@4.1.13)(@types/node@22.19.21)(happy-dom@16.8.1)(jiti@1.21.7)(yaml@2.9.0)
+        version: 3.2.6(@types/debug@4.1.13)(@types/node@22.19.21)(happy-dom@20.10.3)(jiti@1.21.7)(yaml@2.9.0)
       zod:
         specifier: ^4.4.3
         version: 4.4.3
@@ -57,19 +57,19 @@ importers:
     devDependencies:
       '@langchain/core':
         specifier: ^1.1.49
-        version: 1.1.49
+        version: 1.1.49(ws@8.21.0)
       '@types/node':
         specifier: ^22.10.7
         version: 22.19.21
       '@vitest/coverage-v8':
         specifier: ^3.0.4
-        version: 3.2.6(vitest@3.2.6(@types/debug@4.1.13)(@types/node@22.19.21)(happy-dom@16.8.1)(jiti@1.21.7)(yaml@2.9.0))
+        version: 3.2.6(vitest@3.2.6(@types/debug@4.1.13)(@types/node@22.19.21)(happy-dom@20.10.3)(jiti@1.21.7)(yaml@2.9.0))
       typescript:
         specifier: ^5.7.3
         version: 5.9.3
       vitest:
         specifier: ^3.0.4
-        version: 3.2.6(@types/debug@4.1.13)(@types/node@22.19.21)(happy-dom@16.8.1)(jiti@1.21.7)(yaml@2.9.0)
+        version: 3.2.6(@types/debug@4.1.13)(@types/node@22.19.21)(happy-dom@20.10.3)(jiti@1.21.7)(yaml@2.9.0)
       zod:
         specifier: ^4.4.3
         version: 4.4.3
@@ -81,13 +81,13 @@ importers:
         version: 22.19.21
       '@vitest/coverage-v8':
         specifier: ^3.0.4
-        version: 3.2.6(vitest@3.2.6(@types/debug@4.1.13)(@types/node@22.19.21)(happy-dom@16.8.1)(jiti@1.21.7)(yaml@2.9.0))
+        version: 3.2.6(vitest@3.2.6(@types/debug@4.1.13)(@types/node@22.19.21)(happy-dom@20.10.3)(jiti@1.21.7)(yaml@2.9.0))
       typescript:
         specifier: ^5.7.3
         version: 5.9.3
       vitest:
         specifier: ^3.0.4
-        version: 3.2.6(@types/debug@4.1.13)(@types/node@22.19.21)(happy-dom@16.8.1)(jiti@1.21.7)(yaml@2.9.0)
+        version: 3.2.6(@types/debug@4.1.13)(@types/node@22.19.21)(happy-dom@20.10.3)(jiti@1.21.7)(yaml@2.9.0)
 
   packages/server:
     dependencies:
@@ -148,13 +148,13 @@ importers:
         version: 8.20.0
       '@vitest/coverage-v8':
         specifier: ^3.0.4
-        version: 3.2.6(vitest@3.2.6(@types/debug@4.1.13)(@types/node@22.19.21)(happy-dom@16.8.1)(jiti@1.21.7)(yaml@2.9.0))
+        version: 3.2.6(vitest@3.2.6(@types/debug@4.1.13)(@types/node@22.19.21)(happy-dom@20.10.3)(jiti@1.21.7)(yaml@2.9.0))
       typescript:
         specifier: ^5.7.3
         version: 5.9.3
       vitest:
         specifier: ^3.0.4
-        version: 3.2.6(@types/debug@4.1.13)(@types/node@22.19.21)(happy-dom@16.8.1)(jiti@1.21.7)(yaml@2.9.0)
+        version: 3.2.6(@types/debug@4.1.13)(@types/node@22.19.21)(happy-dom@20.10.3)(jiti@1.21.7)(yaml@2.9.0)
 
   packages/shared:
     dependencies:
@@ -167,13 +167,13 @@ importers:
         version: 22.19.21
       '@vitest/coverage-v8':
         specifier: ^3.0.4
-        version: 3.2.6(vitest@3.2.6(@types/debug@4.1.13)(@types/node@22.19.21)(happy-dom@16.8.1)(jiti@1.21.7)(yaml@2.9.0))
+        version: 3.2.6(vitest@3.2.6(@types/debug@4.1.13)(@types/node@22.19.21)(happy-dom@20.10.3)(jiti@1.21.7)(yaml@2.9.0))
       typescript:
         specifier: ^5.7.3
         version: 5.9.3
       vitest:
         specifier: ^3.0.4
-        version: 3.2.6(@types/debug@4.1.13)(@types/node@22.19.21)(happy-dom@16.8.1)(jiti@1.21.7)(yaml@2.9.0)
+        version: 3.2.6(@types/debug@4.1.13)(@types/node@22.19.21)(happy-dom@20.10.3)(jiti@1.21.7)(yaml@2.9.0)
 
   packages/web:
     dependencies:
@@ -207,13 +207,13 @@ importers:
         version: 4.7.0(vite@6.4.3(@types/node@22.19.21)(jiti@1.21.7)(yaml@2.9.0))
       '@vitest/coverage-v8':
         specifier: ^3.0.4
-        version: 3.2.6(vitest@3.2.6(@types/debug@4.1.13)(@types/node@22.19.21)(happy-dom@16.8.1)(jiti@1.21.7)(yaml@2.9.0))
+        version: 3.2.6(vitest@3.2.6(@types/debug@4.1.13)(@types/node@22.19.21)(happy-dom@20.10.3)(jiti@1.21.7)(yaml@2.9.0))
       autoprefixer:
         specifier: ^10.5.0
         version: 10.5.0(postcss@8.5.15)
       happy-dom:
-        specifier: ^16.7.2
-        version: 16.8.1
+        specifier: ^20.10.3
+        version: 20.10.3
       postcss:
         specifier: ^8.5.15
         version: 8.5.15
@@ -228,7 +228,7 @@ importers:
         version: 6.4.3(@types/node@22.19.21)(jiti@1.21.7)(yaml@2.9.0)
       vitest:
         specifier: ^3.0.4
-        version: 3.2.6(@types/debug@4.1.13)(@types/node@22.19.21)(happy-dom@16.8.1)(jiti@1.21.7)(yaml@2.9.0)
+        version: 3.2.6(@types/debug@4.1.13)(@types/node@22.19.21)(happy-dom@20.10.3)(jiti@1.21.7)(yaml@2.9.0)
 
 packages:
 
@@ -991,6 +991,12 @@ packages:
   '@types/semver@7.7.1':
     resolution: {integrity: sha512-FmgJfu+MOcQ370SD0ev7EI8TlCAfKYU+B4m5T3yXc1CiRN94g/SZPtsCkk506aUDtlMnFZvasDwHHUcZUEaYuA==}
 
+  '@types/whatwg-mimetype@3.0.2':
+    resolution: {integrity: sha512-c2AKvDT8ToxLIOUlN51gTiHXflsfIFisS4pO7pDPoKouJCESkhZnEy623gwP9laCy5lnLDAw1vAzu2vM2YLOrA==}
+
+  '@types/ws@8.18.1':
+    resolution: {integrity: sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==}
+
   '@typescript-eslint/eslint-plugin@8.61.0':
     resolution: {integrity: sha512-bFNvl9ZczlVb+wR2Akszf3gHfKVj/8WanXaGJ3UstTA7brNKg0cNdk6X1Psu5V7MZ2oQtzZKOEzIUehaoxbDGw==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
@@ -1224,6 +1230,10 @@ packages:
     engines: {node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7}
     hasBin: true
 
+  buffer-image-size@0.6.4:
+    resolution: {integrity: sha512-nEh+kZOPY1w+gcCMobZ6ETUp9WfibndnosbpwB1iJk/8Gt5ZF2bhS6+B6bPYz424KtwsR6Rflc3tCz1/ghX2dQ==}
+    engines: {node: '>=4.0'}
+
   bytes@3.1.2:
     resolution: {integrity: sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==}
     engines: {node: '>= 0.8'}
@@ -1395,6 +1405,10 @@ packages:
   encodeurl@2.0.0:
     resolution: {integrity: sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==}
     engines: {node: '>= 0.8'}
+
+  entities@7.0.1:
+    resolution: {integrity: sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA==}
+    engines: {node: '>=0.12'}
 
   error-ex@1.3.4:
     resolution: {integrity: sha512-sqQamAnR14VgCr1A618A3sGrygcpK+HEbenA/HiEAkkUwcZIIB/tgWqHFxWgOyDh4nB4JCRimh79dR5Ywc9MDQ==}
@@ -1658,9 +1672,9 @@ packages:
     engines: {node: '>=14.0.0', yarn: ^1.22.22}
     hasBin: true
 
-  happy-dom@16.8.1:
-    resolution: {integrity: sha512-n0QrmT9lD81rbpKsyhnlz3DgnMZlaOkJPpgi746doA+HvaMC79bdWkwjrNnGJRvDrWTI8iOcJiVTJ5CdT/AZRw==}
-    engines: {node: '>=18.0.0'}
+  happy-dom@20.10.3:
+    resolution: {integrity: sha512-Hjdiy8RziuCcn5z04QI/rlsNuQoG8P0xxjgvsSMpi89cvIXIOcucQtiHS1yHSShxoBcSCeYqAskINmTiy/mlfw==}
+    engines: {node: '>=20.0.0'}
 
   has-flag@4.0.0:
     resolution: {integrity: sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==}
@@ -2679,10 +2693,6 @@ packages:
       jsdom:
         optional: true
 
-  webidl-conversions@7.0.0:
-    resolution: {integrity: sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==}
-    engines: {node: '>=12'}
-
   whatwg-mimetype@3.0.0:
     resolution: {integrity: sha512-nt+N2dzIutVRxARx1nghPKGv1xHikU7HKdfafKkLNLindmPU/ch3U31NOCGGA/dmPcmb1VlofO0vnKAcsm0o/Q==}
     engines: {node: '>=12'}
@@ -2711,6 +2721,18 @@ packages:
 
   wrappy@1.0.2:
     resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==}
+
+  ws@8.21.0:
+    resolution: {integrity: sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==}
+    engines: {node: '>=10.0.0'}
+    peerDependencies:
+      bufferutil: ^4.0.1
+      utf-8-validate: '>=5.0.2'
+    peerDependenciesMeta:
+      bufferutil:
+        optional: true
+      utf-8-validate:
+        optional: true
 
   xtend@4.0.2:
     resolution: {integrity: sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==}
@@ -3165,12 +3187,12 @@ snapshots:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.5
 
-  '@langchain/core@1.1.49':
+  '@langchain/core@1.1.49(ws@8.21.0)':
     dependencies:
       '@cfworker/json-schema': 4.1.1
       '@standard-schema/spec': 1.1.0
       js-tiktoken: 1.0.21
-      langsmith: 0.7.7
+      langsmith: 0.7.7(ws@8.21.0)
       mustache: 4.2.0
       p-queue: 6.6.2
       zod: 4.4.3
@@ -3448,6 +3470,12 @@ snapshots:
 
   '@types/semver@7.7.1': {}
 
+  '@types/whatwg-mimetype@3.0.2': {}
+
+  '@types/ws@8.18.1':
+    dependencies:
+      '@types/node': 22.19.21
+
   '@typescript-eslint/eslint-plugin@8.61.0(@typescript-eslint/parser@8.61.0(eslint@9.39.4(jiti@1.21.7))(typescript@5.9.3))(eslint@9.39.4(jiti@1.21.7))(typescript@5.9.3)':
     dependencies:
       '@eslint-community/regexpp': 4.12.2
@@ -3551,7 +3579,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@vitest/coverage-v8@3.2.6(vitest@3.2.6(@types/debug@4.1.13)(@types/node@22.19.21)(happy-dom@16.8.1)(jiti@1.21.7)(yaml@2.9.0))':
+  '@vitest/coverage-v8@3.2.6(vitest@3.2.6(@types/debug@4.1.13)(@types/node@22.19.21)(happy-dom@20.10.3)(jiti@1.21.7)(yaml@2.9.0))':
     dependencies:
       '@ampproject/remapping': 2.3.0
       '@bcoe/v8-coverage': 1.0.2
@@ -3566,7 +3594,7 @@ snapshots:
       std-env: 3.10.0
       test-exclude: 7.0.2
       tinyrainbow: 2.0.0
-      vitest: 3.2.6(@types/debug@4.1.13)(@types/node@22.19.21)(happy-dom@16.8.1)(jiti@1.21.7)(yaml@2.9.0)
+      vitest: 3.2.6(@types/debug@4.1.13)(@types/node@22.19.21)(happy-dom@20.10.3)(jiti@1.21.7)(yaml@2.9.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -3743,6 +3771,10 @@ snapshots:
       node-releases: 2.0.47
       update-browserslist-db: 1.2.3(browserslist@4.28.2)
 
+  buffer-image-size@0.6.4:
+    dependencies:
+      '@types/node': 22.19.21
+
   bytes@3.1.2: {}
 
   cac@6.7.14: {}
@@ -3881,6 +3913,8 @@ snapshots:
   emoji-regex@9.2.2: {}
 
   encodeurl@2.0.0: {}
+
+  entities@7.0.1: {}
 
   error-ex@1.3.4:
     dependencies:
@@ -4252,10 +4286,18 @@ snapshots:
       - supports-color
       - typescript
 
-  happy-dom@16.8.1:
+  happy-dom@20.10.3:
     dependencies:
-      webidl-conversions: 7.0.0
+      '@types/node': 22.19.21
+      '@types/whatwg-mimetype': 3.0.2
+      '@types/ws': 8.18.1
+      buffer-image-size: 0.6.4
+      entities: 7.0.1
       whatwg-mimetype: 3.0.0
+      ws: 8.21.0
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
 
   has-flag@4.0.0: {}
 
@@ -4412,9 +4454,11 @@ snapshots:
     dependencies:
       json-buffer: 3.0.1
 
-  langsmith@0.7.7:
+  langsmith@0.7.7(ws@8.21.0):
     dependencies:
       p-queue: 6.6.2
+    optionalDependencies:
+      ws: 8.21.0
 
   levn@0.4.1:
     dependencies:
@@ -5167,7 +5211,7 @@ snapshots:
       jiti: 1.21.7
       yaml: 2.9.0
 
-  vitest@3.2.6(@types/debug@4.1.13)(@types/node@22.19.21)(happy-dom@16.8.1)(jiti@1.21.7)(yaml@2.9.0):
+  vitest@3.2.6(@types/debug@4.1.13)(@types/node@22.19.21)(happy-dom@20.10.3)(jiti@1.21.7)(yaml@2.9.0):
     dependencies:
       '@types/chai': 5.2.3
       '@vitest/expect': 3.2.6
@@ -5195,7 +5239,7 @@ snapshots:
     optionalDependencies:
       '@types/debug': 4.1.13
       '@types/node': 22.19.21
-      happy-dom: 16.8.1
+      happy-dom: 20.10.3
     transitivePeerDependencies:
       - jiti
       - less
@@ -5209,8 +5253,6 @@ snapshots:
       - terser
       - tsx
       - yaml
-
-  webidl-conversions@7.0.0: {}
 
   whatwg-mimetype@3.0.0: {}
 
@@ -5238,6 +5280,8 @@ snapshots:
       strip-ansi: 7.2.0
 
   wrappy@1.0.2: {}
+
+  ws@8.21.0: {}
 
   xtend@4.0.2: {}
 


### PR DESCRIPTION
Addresses the Dependabot security alerts.

## happy-dom (Critical + 2 High) — FIXED
`happy-dom` is a `packages/web` **devDependency** (the vitest DOM test env), never shipped in the deployed server/web runtime. It was 16.8.1, vulnerable to a Critical VM-context-escape RCE and two High advisories (unsanitized ESM export names; page-origin fetch credentials), all fixed in `>=20.8.9`. Bumped to `^20.10.3`. **Web tests (161) pass** under the new env and the **full build is green**. `pnpm audit --prod` (the CI gate) is clean.

## esbuild (High) — not applicable, dismissed
The esbuild advisory is a **Deno-only install vector** (`NPM_CONFIG_REGISTRY` in Deno's esbuild installer). This repo installs via pnpm with lockfile integrity and never via Deno, so the vulnerable path isn't used. esbuild is also a transitive build dep (vite/vitest); forcing `>=0.28.1` breaks the pinned vite (incompatible esbuild service API) and would require a vite major upgrade. Dismissed as `not_used` with a comment; will clear naturally when vite/vitest are upgraded.