### PR TITLE
feat(sdk-python): Python SDK for governing Python agents (CrewAI, LangChain-py, ...)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -90,3 +90,20 @@ jobs:
       - name: Tear down
         if: always()
         run: docker compose down -v
+
+  # The Python SDK is outside the pnpm/turbo workspace, so it gets its own lane:
+  # lint (ruff), strict types (mypy), and tests (pytest, no server needed).
+  python-sdk:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: packages/sdk-python
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - run: pip install -e ".[dev]"
+      - run: ruff check .
+      - run: mypy
+      - run: pytest -q

--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,12 @@ docker-compose.override.yml
 
 # Local agent tooling / transient worktrees
 .claude/
+
+# Python (sdk-python)
+__pycache__/
+*.egg-info/
+build/
+.venv/
+.pytest_cache/
+.mypy_cache/
+.ruff_cache/

--- a/LICENSING.md
+++ b/LICENSING.md
@@ -8,7 +8,7 @@ license** available for organizations whose policies preclude AGPL-3.0.
 | Component | Package(s) | License |
 | --- | --- | --- |
 | Control plane | `packages/server`, `packages/web`, `packages/shared` | **AGPL-3.0-only** ([LICENSE](LICENSE)) |
-| Integration layer | `packages/sdk`, `packages/connector-langchain`, `packages/connector-claude-agent`, `examples/` | **Apache-2.0** ([sdk](packages/sdk/LICENSE), [langchain](packages/connector-langchain/LICENSE), [claude-agent](packages/connector-claude-agent/LICENSE), [examples](examples/LICENSE)) |
+| Integration layer | `packages/sdk`, `packages/sdk-python`, `packages/connector-langchain`, `packages/connector-claude-agent`, `examples/` | **Apache-2.0** ([sdk](packages/sdk/LICENSE), [sdk-python](packages/sdk-python/LICENSE), [langchain](packages/connector-langchain/LICENSE), [claude-agent](packages/connector-claude-agent/LICENSE), [examples](examples/LICENSE)) |
 
 **Why AGPL for the core.** The control plane is the part an auditor relies on:
 the enforcement engine and the tamper-evident audit chain. AGPL-3.0 keeps it

--- a/README.md
+++ b/README.md
@@ -144,7 +144,7 @@ On April 17, 2026 the Federal Reserve replaced SR 11-7 with SR 26-2, which expli
 - flows with approval gates, retries, timeouts, and a crash-recovery watchdog
 - n-of-m named approvals: quorums, named approver lists, requester self-approval forbidden by default (fail closed)
 - enforced role limits & budgets: per-skill invocation caps, fail-closed amount ceilings, run-level invocation and token budgets
-- proxy sessions wrapping LangGraph/CrewAI/Claude Agent SDK agents with grant checks, SoD, and the audit trail, no migration into the flow engine; typed connectors for [LangChain](packages/connector-langchain) ([demo](examples/connectors/langchain/README.md)) and the [Claude Agent SDK](packages/connector-claude-agent), plus generic [middleware recipes](examples/middleware/README.md)
+- proxy sessions wrapping LangGraph/CrewAI/Claude Agent SDK agents with grant checks, SoD, and the audit trail, no migration into the flow engine; typed connectors for [LangChain](packages/connector-langchain) ([demo](examples/connectors/langchain/README.md)) and the [Claude Agent SDK](packages/connector-claude-agent), a [Python SDK](packages/sdk-python) for CrewAI/LangChain-Python/etc., plus generic [middleware recipes](examples/middleware/README.md)
 - hash-chained audit log with Ed25519-signed export bundles and a CLI verifier
 - evidence packs: `makerchecker audit report --run <id>` renders a self-contained HTML run report with chain verification; `makerchecker audit access-review` renders the role/grant/SoD review (also JSON at `/api/reports/access-review`)
 - cron triggers scheduled at boot (runs start as `system/cron` from the latest published version)
@@ -157,7 +157,7 @@ On April 17, 2026 the Federal Reserve replaced SR 11-7 with SR 26-2, which expli
 ## License
 
 - `packages/server`, `packages/web`, `packages/shared`: **AGPL-3.0** ([LICENSE](LICENSE))
-- `packages/sdk`, `packages/connector-langchain`, `packages/connector-claude-agent`, and `examples/`: **Apache-2.0** ([packages/sdk/LICENSE](packages/sdk/LICENSE), [packages/connector-langchain/LICENSE](packages/connector-langchain/LICENSE), [packages/connector-claude-agent/LICENSE](packages/connector-claude-agent/LICENSE), [examples/LICENSE](examples/LICENSE)), code you embed in your own systems never carries AGPL obligations
+- `packages/sdk`, `packages/sdk-python`, `packages/connector-langchain`, `packages/connector-claude-agent`, and `examples/`: **Apache-2.0** ([packages/sdk/LICENSE](packages/sdk/LICENSE), [packages/sdk-python/LICENSE](packages/sdk-python/LICENSE), [packages/connector-langchain/LICENSE](packages/connector-langchain/LICENSE), [packages/connector-claude-agent/LICENSE](packages/connector-claude-agent/LICENSE), [examples/LICENSE](examples/LICENSE)), code you embed in your own systems never carries AGPL obligations
 - A **commercial license** (no copyleft obligation) is available for organizations whose policies preclude AGPL-3.0: hello@makerchecker.ai
 
 Licensing rationale and the commercial/CLA model: [LICENSING.md](LICENSING.md). The audit chain is specified for independent offline verification ([audit spec](docs/audit-spec.md)); security reports are welcome ([SECURITY.md](SECURITY.md)).

--- a/packages/sdk-python/LICENSE
+++ b/packages/sdk-python/LICENSE
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/packages/sdk-python/README.md
+++ b/packages/sdk-python/README.md
@@ -1,0 +1,69 @@
+# makerchecker (Python SDK)
+
+Govern AI-agent tool calls through MakerChecker from Python. This is a thin,
+typed HTTP client over a running MakerChecker server plus the framework-agnostic
+`governed_tool` wrapper. It adds no server logic and never touches the audit
+core; it brings the same deny-by-default grants, segregation of duties, and
+hash-chained signed audit to Python agents (CrewAI, LangChain-Python,
+LlamaIndex, AutoGen, or a plain function).
+
+```bash
+pip install makerchecker
+```
+
+```python
+from makerchecker import create_client, governed_tool, GovernanceDeniedError
+
+client = create_client("http://localhost:3000", api_key="mk_...")
+session = client.proxy.open_session("crew-run")["session"]
+
+# Wrap any tool function: check -> (deny raises) -> run -> record.
+ingest = governed_tool(
+    client, session["id"], "recon-preparer", "csv-ingest@1",
+    lambda i: read_csv(i["path"]),
+)
+
+result = ingest({"path": "statement.csv"})   # raises GovernanceDeniedError if denied
+client.proxy.close_session(session["id"])
+```
+
+`governed_tool` does, on every call:
+
+1. `client.proxy.check` — a deny raises `GovernanceDeniedError` **before** your
+   tool runs (deny by default, fail closed);
+2. runs your function;
+3. records the output, or, if it raises, records the error and re-raises.
+
+## CrewAI
+
+CrewAI tools are plain callables under the hood, so wrap the implementation and
+call it from your tool:
+
+```python
+from crewai.tools import tool
+
+ingest = governed_tool(client, session["id"], "recon-preparer", "csv-ingest@1",
+                       lambda i: read_csv(i["path"]))
+
+@tool("csv_ingest")
+def csv_ingest(path: str) -> str:
+    """Ingest the statement CSV."""
+    return ingest({"path": path})
+```
+
+## LangChain (Python)
+
+```python
+from langchain_core.tools import tool
+
+match = governed_tool(client, session["id"], "recon-preparer", "txn-match@1",
+                      lambda i: match_txns(i))
+
+@tool
+def txn_match(statement: list, ledger: list) -> dict:
+    """Match transactions."""
+    return match({"statement": statement, "ledger": ledger})
+```
+
+Apache-2.0: embedding this SDK in your own systems never carries AGPL
+obligations. The MakerChecker server it talks to is AGPL-3.0.

--- a/packages/sdk-python/pyproject.toml
+++ b/packages/sdk-python/pyproject.toml
@@ -1,0 +1,39 @@
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[project]
+name = "makerchecker"
+version = "1.0.0"
+description = "Python SDK for MakerChecker: govern AI-agent tool calls with deny-by-default grants, segregation of duties, and a hash-chained audit trail."
+readme = "README.md"
+requires-python = ">=3.9"
+license = { text = "Apache-2.0" }
+authors = [{ name = "MakerChecker" }]
+keywords = ["ai-agents", "governance", "audit", "segregation-of-duties", "crewai", "langchain"]
+classifiers = [
+  "License :: OSI Approved :: Apache Software License",
+  "Programming Language :: Python :: 3",
+  "Typing :: Typed",
+]
+dependencies = ["httpx>=0.24"]
+
+[project.urls]
+Homepage = "https://makerchecker.ai"
+Repository = "https://github.com/sammysltd/makerchecker"
+
+[project.optional-dependencies]
+dev = ["pytest>=8", "ruff>=0.6", "mypy>=1.8"]
+
+[tool.hatch.build.targets.wheel]
+packages = ["src/makerchecker"]
+
+[tool.ruff]
+line-length = 100
+
+[tool.ruff.lint]
+select = ["E", "F", "I", "UP", "B"]
+
+[tool.mypy]
+strict = true
+files = ["src/makerchecker"]

--- a/packages/sdk-python/src/makerchecker/__init__.py
+++ b/packages/sdk-python/src/makerchecker/__init__.py
@@ -1,0 +1,23 @@
+"""MakerChecker Python SDK.
+
+Govern AI-agent tool calls through a running MakerChecker server: deny-by-default
+grants, segregation of duties, and a hash-chained, signed audit trail. This SDK
+is a thin HTTP client plus the framework-agnostic ``governed_tool`` wrapper; the
+server holds all the governance and audit logic.
+"""
+
+from __future__ import annotations
+
+from ._client import ApiError, CheckResult, Client, create_client
+from ._governance import GovernanceDeniedError, governed_tool
+
+__version__ = "1.0.0"
+
+__all__ = [
+    "ApiError",
+    "CheckResult",
+    "Client",
+    "GovernanceDeniedError",
+    "create_client",
+    "governed_tool",
+]

--- a/packages/sdk-python/src/makerchecker/_client.py
+++ b/packages/sdk-python/src/makerchecker/_client.py
@@ -1,0 +1,159 @@
+"""A thin, typed HTTP client for the MakerChecker API.
+
+Mirrors ``@makerchecker/sdk`` (TypeScript). It adds no server logic: it talks to
+a running MakerChecker server over HTTP, so a Python agent (CrewAI,
+LangChain-Python, LlamaIndex, AutoGen, or a plain function) can open a proxy
+session and run governed tool calls through it.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+from urllib.parse import quote
+
+import httpx
+
+# Sentinel so ``record(output=None)`` is distinguishable from "no output given"
+# (None is a legitimate tool output, mirroring the TS SDK's `output?: unknown`).
+_UNSET: Any = object()
+
+
+class ApiError(Exception):
+    """Raised when the MakerChecker API returns a non-2xx response."""
+
+    def __init__(self, status: int, body: str) -> None:
+        super().__init__(f"API request failed with status {status}")
+        self.status = status
+        self.body = body
+
+
+@dataclass(frozen=True)
+class CheckResult:
+    """Outcome of a proxy authorization check.
+
+    ``allowed`` is the discriminator: when True, ``check_id`` is set; when
+    False, ``code`` and ``reason`` explain the deny.
+    """
+
+    allowed: bool
+    check_id: str | None = None
+    code: str | None = None
+    reason: str | None = None
+
+    @classmethod
+    def _from_dict(cls, data: dict[str, Any]) -> CheckResult:
+        return cls(
+            allowed=bool(data.get("allowed")),
+            check_id=data.get("checkId"),
+            code=data.get("code"),
+            reason=data.get("reason"),
+        )
+
+
+class _Proxy:
+    """The proxy-session surface: open a session, then check -> record per call."""
+
+    def __init__(self, client: Client) -> None:
+        self._client = client
+
+    def open_session(self, label: str, external_ref: str | None = None) -> dict[str, Any]:
+        body: dict[str, Any] = {"label": label}
+        if external_ref is not None:
+            body["externalRef"] = external_ref
+        return self._client._request("POST", "/api/proxy/sessions", body)
+
+    def check(
+        self,
+        session_id: str,
+        agent_name: str,
+        skill_ref: str,
+        input: dict[str, Any] | None = None,
+    ) -> CheckResult:
+        body: dict[str, Any] = {"agentName": agent_name, "skillRef": skill_ref}
+        if input is not None:
+            body["input"] = input
+        data = self._client._request("POST", f"/api/proxy/sessions/{session_id}/check", body)
+        return CheckResult._from_dict(data)
+
+    def record(
+        self,
+        session_id: str,
+        check_id: str,
+        output: Any = _UNSET,
+        error: Any = _UNSET,
+    ) -> dict[str, Any]:
+        body: dict[str, Any] = {"checkId": check_id}
+        if output is not _UNSET:
+            body["output"] = output
+        if error is not _UNSET:
+            body["error"] = error
+        return self._client._request("POST", f"/api/proxy/sessions/{session_id}/record", body)
+
+    def close_session(self, session_id: str) -> dict[str, Any]:
+        return self._client._request("POST", f"/api/proxy/sessions/{session_id}/close")
+
+    def get_session(self, session_id: str) -> dict[str, Any]:
+        return self._client._request("GET", f"/api/proxy/sessions/{session_id}")
+
+
+class Client:
+    """A MakerChecker API client.
+
+    Pass ``http`` to inject a configured ``httpx.Client`` (used in tests with a
+    mock transport); otherwise one is created for ``base_url`` with the Bearer
+    API key. Usable as a context manager.
+    """
+
+    def __init__(
+        self,
+        base_url: str,
+        api_key: str | None = None,
+        *,
+        http: httpx.Client | None = None,
+    ) -> None:
+        if http is not None:
+            self._http = http
+            self._owns_http = False
+        else:
+            headers: dict[str, str] = {}
+            if api_key is not None:
+                headers["authorization"] = f"Bearer {api_key}"
+            self._http = httpx.Client(base_url=base_url.rstrip("/"), headers=headers, timeout=30.0)
+            self._owns_http = True
+        self.proxy = _Proxy(self)
+
+    def _request(
+        self, method: str, path: str, body: dict[str, Any] | None = None
+    ) -> dict[str, Any]:
+        resp = self._http.request(method, path, json=body if body is not None else None)
+        if resp.status_code >= 400:
+            raise ApiError(resp.status_code, resp.text)
+        result: dict[str, Any] = resp.json()
+        return result
+
+    def health(self) -> dict[str, Any]:
+        return self._request("GET", "/healthz")
+
+    def trigger_flow(self, name: str, input: dict[str, Any] | None = None) -> dict[str, Any]:
+        return self._request(
+            "POST", f"/api/flows/{quote(name)}/runs", input if input is not None else {}
+        )
+
+    def verify_audit(self) -> dict[str, Any]:
+        return self._request("GET", "/api/audit/verify")
+
+    def close(self) -> None:
+        if self._owns_http:
+            self._http.close()
+
+    def __enter__(self) -> Client:
+        return self
+
+    def __exit__(self, *exc: object) -> None:
+        self.close()
+
+
+def create_client(base_url: str, api_key: str | None = None) -> Client:
+    """Convenience constructor mirroring the TypeScript SDK's ``createClient``."""
+    return Client(base_url, api_key)

--- a/packages/sdk-python/src/makerchecker/_governance.py
+++ b/packages/sdk-python/src/makerchecker/_governance.py
@@ -1,0 +1,70 @@
+"""``governed_tool`` — wrap, don't migrate.
+
+Wraps any Python tool function so every call passes through MakerChecker first:
+check -> (deny raises ``GovernanceDeniedError`` before the tool runs) -> run ->
+record the output (or the error, which is re-raised). Framework-agnostic: use it
+inside a CrewAI ``@tool``, a LangChain ``StructuredTool``, or a bare function.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Callable, TypeVar
+
+from ._client import Client
+
+T = TypeVar("T")
+
+
+class GovernanceDeniedError(Exception):
+    """Raised when MakerChecker denies a governed call (before the tool runs)."""
+
+    def __init__(self, code: str, reason: str) -> None:
+        super().__init__(f"governance denied ({code}): {reason}")
+        self.code = code
+        self.reason = reason
+
+
+def governed_tool(
+    client: Client,
+    session_id: str,
+    agent_name: str,
+    skill_ref: str,
+    fn: Callable[[dict[str, Any]], T],
+) -> Callable[[dict[str, Any]], T]:
+    """Return a governed version of ``fn``.
+
+    The wrapper takes the tool input (a dict) and:
+
+      1. calls ``client.proxy.check`` — a deny raises :class:`GovernanceDeniedError`
+         BEFORE ``fn`` runs (deny by default, fail closed);
+      2. runs ``fn(input)``;
+      3. records the output, or, if ``fn`` raises, records the error and re-raises.
+
+    Example (CrewAI)::
+
+        from crewai.tools import tool
+
+        ingest_impl = governed_tool(client, session.id, "recon-preparer",
+                                    "csv-ingest@1", lambda i: read_csv(i["path"]))
+
+        @tool("csv_ingest")
+        def csv_ingest(path: str) -> str:
+            return ingest_impl({"path": path})
+    """
+
+    def wrapped(input: dict[str, Any]) -> T:
+        check = client.proxy.check(session_id, agent_name, skill_ref, input=input)
+        if not check.allowed:
+            raise GovernanceDeniedError(check.code or "denied", check.reason or "denied")
+        # The server guarantees a check_id on an allowed result.
+        check_id = check.check_id
+        assert check_id is not None
+        try:
+            output = fn(input)
+            client.proxy.record(session_id, check_id, output=output)
+            return output
+        except Exception as err:
+            client.proxy.record(session_id, check_id, error={"message": str(err)})
+            raise
+
+    return wrapped

--- a/packages/sdk-python/tests/test_client.py
+++ b/packages/sdk-python/tests/test_client.py
@@ -1,0 +1,85 @@
+from __future__ import annotations
+
+import json
+
+import httpx
+import pytest
+
+from makerchecker import ApiError, Client
+
+
+def make_client(handler: object) -> Client:
+    transport = httpx.MockTransport(handler)  # type: ignore[arg-type]
+    http = httpx.Client(transport=transport, base_url="http://test")
+    return Client("http://test", http=http)
+
+
+def test_open_session_check_record_close() -> None:
+    seen = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        body = json.loads(request.content) if request.content else None
+        seen.append((request.method, request.url.path, body))
+        path = request.url.path
+        if path == "/api/proxy/sessions":
+            return httpx.Response(200, json={"session": {"id": "ps-1", "status": "open"}})
+        if path.endswith("/check"):
+            return httpx.Response(200, json={"allowed": True, "checkId": "ck-1"})
+        if path.endswith("/record"):
+            return httpx.Response(200, json={"ok": True})
+        if path.endswith("/close"):
+            return httpx.Response(200, json={"session": {"id": "ps-1", "status": "closed"}})
+        return httpx.Response(404, text="not found")
+
+    c = make_client(handler)
+    assert c.proxy.open_session("run")["session"]["id"] == "ps-1"
+    check = c.proxy.check("ps-1", "bot", "double@1", input={"n": 21})
+    assert check.allowed and check.check_id == "ck-1"
+    assert c.proxy.record("ps-1", "ck-1", output={"doubled": 42})["ok"] is True
+    c.proxy.close_session("ps-1")
+
+    check_req = next(s for s in seen if s[1].endswith("/check"))
+    assert check_req[2] == {"agentName": "bot", "skillRef": "double@1", "input": {"n": 21}}
+
+
+def test_check_deny_shape() -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            200, json={"allowed": False, "code": "skill_not_granted", "reason": "no grant"}
+        )
+
+    res = make_client(handler).proxy.check("ps-1", "bot", "x@1")
+    assert res.allowed is False
+    assert res.code == "skill_not_granted"
+    assert res.reason == "no grant"
+
+
+def test_trigger_and_verify() -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        if request.url.path.endswith("/runs"):
+            return httpx.Response(201, json={"runId": "r-1"})
+        if request.url.path == "/api/audit/verify":
+            return httpx.Response(200, json={"ok": True, "count": 5, "headHash": "abc"})
+        return httpx.Response(404, text="no")
+
+    c = make_client(handler)
+    assert c.trigger_flow("daily-cash", {"x": 1})["runId"] == "r-1"
+    assert c.verify_audit()["ok"] is True
+
+
+def test_api_error_on_non_2xx() -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(401, text="missing API key (authorization: Bearer mk_...)")
+
+    with pytest.raises(ApiError) as exc:
+        make_client(handler).proxy.check("ps-1", "bot", "x@1")
+    assert exc.value.status == 401
+    assert "missing API key" in exc.value.body
+
+
+def test_builds_bearer_auth_header() -> None:
+    c = Client("http://x/", "mk_test")
+    try:
+        assert c._http.headers.get("authorization") == "Bearer mk_test"
+    finally:
+        c.close()

--- a/packages/sdk-python/tests/test_governance.py
+++ b/packages/sdk-python/tests/test_governance.py
@@ -1,0 +1,73 @@
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from makerchecker import CheckResult, GovernanceDeniedError, governed_tool
+
+
+class FakeProxy:
+    def __init__(self, result: CheckResult) -> None:
+        self._result = result
+        self.checks: list[tuple[Any, ...]] = []
+        self.records: list[dict[str, Any]] = []
+
+    def check(self, session_id, agent_name, skill_ref, input=None):  # type: ignore[no-untyped-def]
+        self.checks.append((session_id, agent_name, skill_ref, input))
+        return self._result
+
+    def record(self, session_id, check_id, output=..., error=...):  # type: ignore[no-untyped-def]
+        self.records.append(
+            {"session_id": session_id, "check_id": check_id, "output": output, "error": error}
+        )
+        return {"ok": True}
+
+
+class FakeClient:
+    def __init__(self, result: CheckResult) -> None:
+        self.proxy = FakeProxy(result)
+
+
+def test_allow_runs_and_records() -> None:
+    c = FakeClient(CheckResult(allowed=True, check_id="ck-1"))
+
+    def fn(i: dict[str, Any]) -> dict[str, Any]:
+        return {"doubled": i["n"] * 2}
+
+    wrapped = governed_tool(c, "ps-1", "bot", "double@1", fn)  # type: ignore[arg-type]
+    assert wrapped({"n": 21}) == {"doubled": 42}
+    assert c.proxy.checks == [("ps-1", "bot", "double@1", {"n": 21})]
+    assert c.proxy.records[0]["check_id"] == "ck-1"
+    assert c.proxy.records[0]["output"] == {"doubled": 42}
+
+
+def test_deny_raises_and_never_runs() -> None:
+    c = FakeClient(CheckResult(allowed=False, code="skill_not_granted", reason="no grant"))
+    ran: list[Any] = []
+
+    def fn(i: dict[str, Any]) -> str:
+        ran.append(i)
+        return "must not run"
+
+    wrapped = governed_tool(c, "ps-1", "bot", "x@1", fn)  # type: ignore[arg-type]
+    with pytest.raises(GovernanceDeniedError) as exc:
+        wrapped({"n": 1})
+    assert exc.value.code == "skill_not_granted"
+    assert exc.value.reason == "no grant"
+    assert ran == []
+    assert c.proxy.records == []  # nothing recorded on a deny
+
+
+def test_tool_error_is_recorded_and_reraised() -> None:
+    c = FakeClient(CheckResult(allowed=True, check_id="ck-9"))
+
+    def fn(i: dict[str, Any]) -> str:
+        raise ValueError("boom")
+
+    wrapped = governed_tool(c, "ps-1", "bot", "f@1", fn)  # type: ignore[arg-type]
+    with pytest.raises(ValueError, match="boom"):
+        wrapped({"n": 1})
+    rec = c.proxy.records[0]
+    assert rec["check_id"] == "ck-9"
+    assert rec["error"] == {"message": "boom"}


### PR DESCRIPTION
Opens the Python agent ecosystem. The repo was TypeScript-only, so a Python agent could only hand-roll raw HTTP calls to govern itself.

## What
Apache-2.0 `makerchecker` package (`packages/sdk-python`):
- a thin, typed **httpx** client mirroring `@makerchecker/sdk`: `proxy.open_session/check/record/close_session/get_session`, `trigger_flow`, `verify_audit`;
- the framework-agnostic **`governed_tool`** wrapper: check → (deny raises `GovernanceDeniedError` before the tool runs) → run → record output/error.

It adds **no server logic** and never touches the audit core — same product, new language. Serves CrewAI, LangChain-Python, LlamaIndex, AutoGen, or plain functions (README shows CrewAI + LangChain-Python patterns).

## Quality
- **ruff** clean, **mypy --strict** clean (PEP 561 `py.typed`), **8 pytest tests** pass (httpx `MockTransport` for the client; a fake client for `governed_tool` covering allow/deny/raise), wheel builds.
- New **`python-sdk` CI lane** (setup-python 3.12 → ruff/mypy/pytest), separate from the pnpm/turbo workspace.
- Wired into README integration + LICENSING Apache table; Python build artifacts gitignored.

A crewai-*internals* typed connector (subclassing CrewAI's tool API) is deferred — CrewAI's tool API churns and 3.13 support is uncertain, and `governed_tool` already covers it cleanly.