### PR TITLE
docs: clean up licensing and feature request

### DIFF
--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -18,4 +18,4 @@ Workarounds you tried, or why existing features don't fit.
 
 **Scope check**
 
-MakerChecker 1.0 does not include drag-and-drop flow builders, SSO/SAML, or multi-tenancy (see the README Status section). Requests in those areas are parked, not rejected.
+MakerChecker 1.0 does not include drag-and-drop flow builders, SSO/SAML, or multi-tenancy (see the README Status section).

--- a/LICENSING.md
+++ b/LICENSING.md
@@ -25,9 +25,7 @@ apply to the MakerChecker service, not to your application.
 Some organizations have procurement or legal policies that do not permit AGPL-3.0
 software, even when self-hosted behind their own firewall. A **commercial
 license** replaces the AGPL-3.0 terms on the core with conventional commercial
-terms (no copyleft obligation). It also funds continued development and is the
-delivery vehicle for closed enterprise add-ons such as SSO/SAML, multi-tenancy
-controls, and HSM/KMS-backed signing keys.
+terms (no copyleft obligation), and funds continued development.
 
 To discuss commercial terms: **hello@makerchecker.ai**.
 

--- a/README.md
+++ b/README.md
@@ -130,7 +130,7 @@ Bundles are Ed25519-signed and carry the manifest needed to recompute the chain.
 
 MakerChecker 1.0. The server, web, shared, integration, and verification paths are covered by unit and integration tests against Postgres in CI.
 
-1.0 has no drag-and-drop flow builder, SSO/SAML, or multi-tenancy. Flow definitions are typed JSON/YAML; SSO/SAML and multi-tenancy are planned commercial add-ons ([LICENSING.md](LICENSING.md)).
+1.0 has no drag-and-drop flow builder, SSO/SAML, or multi-tenancy. Flow definitions are typed JSON/YAML.
 
 ## License
 


### PR DESCRIPTION
Remove the per-feature commercial-paywall framing from the docs.

- **LICENSING.md** — drop the sentence naming SSO/SAML, multi-tenancy, and HSM/KMS as commercial add-ons; keep the generic AGPL-or-commercial-license rationale.
- **README** (Status) — drop the "planned commercial add-ons" clause.
- **feature_request** template — drop the "parked, not rejected" line.

The commercial license stands on the AGPL-aversion rationale alone; no feature is committed to a paid tier before it exists.