### PR TITLE
fix(sod): high-risk steps require a separation-enforcing gate

### DIFF
--- a/packages/server/src/engine/enforcement.ts
+++ b/packages/server/src/engine/enforcement.ts
@@ -8,7 +8,9 @@ import type { PoolClient } from "pg";
  *  1. agent exists and is active
  *  2. every skill@version exists and is published
  *  3. every skill is GRANTED to the agent's role (unrevoked grant — deny by default)
- *  4. high-risk skills require a preceding approval gate in the flow
+ *  4. high-risk skills require a preceding SEPARATION-ENFORCING approval gate
+ *     (identity-mode, forbid_requester not disabled) — a legacy gate the
+ *     requester could self-approve does not satisfy this
  *  5. segregation of duties: no role that conflicts with the agent's role may
  *     already have acted in this run (checked against frozen role snapshots)
  */
@@ -42,8 +44,12 @@ export interface EnforceInput {
   skillRefs: string[];
   /** Run context for SoD evaluation. */
   runId: string;
-  /** Whether an approval gate precedes this step in the flow definition. */
-  hasPrecedingGate: boolean;
+  /**
+   * Whether a SEPARATION-ENFORCING approval gate (identity-mode, forbid_requester
+   * not disabled) precedes this step. A legacy gate the requester could
+   * self-approve is NOT one, so it does not unlock a high-risk skill.
+   */
+  hasSeparationGate: boolean;
 }
 
 export function parseSkillRef(ref: string): { name: string; version: number } {
@@ -141,10 +147,11 @@ export async function enforce(client: PoolClient, input: EnforceInput): Promise<
       );
     }
 
-    if (skill.risk_tier === "high" && !input.hasPrecedingGate) {
+    if (skill.risk_tier === "high" && !input.hasSeparationGate) {
       throw new EnforcementError(
         "high_risk_requires_gate",
-        `skill "${ref}" is high-risk and requires a preceding approval gate`,
+        `skill "${ref}" is high-risk and requires a preceding approval gate that enforces ` +
+          "approver separation (the run's requester cannot approve their own work)",
       );
     }
 

--- a/packages/server/src/engine/engine.integration.test.ts
+++ b/packages/server/src/engine/engine.integration.test.ts
@@ -71,6 +71,16 @@ async function grant(agentName: string, ref: string): Promise<void> {
   );
 }
 
+/** Creates (or reuses) a user and returns its id — needed to decide identity-mode gates. */
+async function seedUser(email: string): Promise<string> {
+  const { rows } = await db.pool.query<{ id: string }>(
+    `INSERT INTO users (email, password_hash, display_name) VALUES ($1, 'x', $1)
+     ON CONFLICT (email) DO UPDATE SET email = EXCLUDED.email RETURNING id`,
+    [email],
+  );
+  return rows[0]!.id;
+}
+
 async function waitForRunStatus(
   runId: string,
   statuses: string[],
@@ -697,19 +707,25 @@ describe("M3 — high-risk skills require gates", () => {
     ).rejects.toThrow(/high-risk.*approval gate/);
   });
 
-  it("publishes and runs a gated high-risk flow end to end", async () => {
+  it("publishes and runs a gated high-risk flow end to end (separation-enforcing gate)", async () => {
     await seedAgent("payments-agent");
     await seedSkill("post-payment@1", async (i) => ({ ...i, posted: true }), "high");
     await seedSkill("draft-payment@1", async (i) => ({ ...i, drafted: true }));
     await grant("payments-agent", "post-payment@1");
     await grant("payments-agent", "draft-payment@1");
+    const checkerId = await seedUser("checker@bank.example");
 
     const { flowVersionId } = await publishFlowVersion(db.pool, {
       definition: {
         name: "gated-payment-flow",
         steps: [
           { key: "draft", agent: "payments-agent", skills: ["draft-payment@1"] },
-          { key: "review", type: "approval_gate", title: "Approve payment batch" },
+          {
+            key: "review",
+            type: "approval_gate",
+            title: "Approve payment batch",
+            approvals: { min_approvals: 1, forbid_requester: true },
+          },
           { key: "post", agent: "payments-agent", skills: ["post-payment@1"] },
         ],
       },
@@ -721,10 +737,12 @@ describe("M3 — high-risk skills require gates", () => {
       "SELECT id FROM approvals WHERE run_id = $1 AND status = 'pending'",
       [runId],
     );
+    // A different identity than the run's requester (USER) must clear it.
     await decideApproval(ctx, {
       approvalId: approval.rows[0]!.id,
       decision: "approved",
-      decidedBy: USER,
+      decidedBy: { type: "user", id: checkerId, name: "checker@bank.example" },
+      userId: checkerId,
     });
     expect(await waitForRunStatus(runId, ["completed", "failed"])).toBe("completed");
   });
@@ -738,10 +756,101 @@ describe("M3 — high-risk skills require gates", () => {
           agentName: "payments-agent",
           skillRefs: ["post-payment@1"],
           runId: "00000000-0000-0000-0000-000000000000",
-          hasPrecedingGate: false,
+          hasSeparationGate: false,
         }),
       ),
     ).rejects.toThrow(/high-risk/);
+  });
+
+  it("rejects publishing a high-risk skill guarded only by a LEGACY (self-approvable) gate", async () => {
+    await seedAgent("payments-agent");
+    await seedSkill("post-payment@1", async (i) => i, "high");
+    await grant("payments-agent", "post-payment@1");
+    await expect(
+      publishFlowVersion(db.pool, {
+        definition: {
+          name: "legacy-gated-high-risk",
+          steps: [
+            { key: "review", type: "approval_gate", title: "Rubber stamp" },
+            { key: "pay", agent: "payments-agent", skills: ["post-payment@1"] },
+          ],
+        },
+        actor: USER,
+      }),
+    ).rejects.toThrow(/enforces approver separation/);
+  });
+
+  it("publishes a high-risk skill behind an identity-mode (forbid_requester) gate", async () => {
+    await seedAgent("payments-agent");
+    await seedSkill("post-payment@1", async (i) => i, "high");
+    await grant("payments-agent", "post-payment@1");
+    const published = await publishFlowVersion(db.pool, {
+      definition: {
+        name: "identity-gated-high-risk",
+        steps: [
+          {
+            key: "review",
+            type: "approval_gate",
+            title: "Four-eyes",
+            approvals: { min_approvals: 1, forbid_requester: true },
+          },
+          { key: "pay", agent: "payments-agent", skills: ["post-payment@1"] },
+        ],
+      },
+      actor: USER,
+    });
+    expect(published.version).toBeGreaterThan(0);
+  });
+
+  // Adversarial: a flow version that predates this rule is immutable, so it can
+  // still reach the engine. Even when its legacy gate is approved by the run's
+  // OWN requester, the high-risk step must fail closed at run time.
+  it("denies a high-risk step behind a legacy gate at RUN TIME, even self-approved", async () => {
+    await seedAgent("legacy-payments-agent");
+    await seedSkill("legacy-draft@1", async (i) => ({ ...i, drafted: true }));
+    await seedSkill("legacy-post@1", async (i) => ({ ...i, posted: true }), "high");
+    await grant("legacy-payments-agent", "legacy-draft@1");
+    await grant("legacy-payments-agent", "legacy-post@1");
+
+    // Insert the version directly, bypassing publish-time validation.
+    const def = {
+      name: "predates-separation-rule",
+      steps: [
+        { key: "draft", agent: "legacy-payments-agent", skills: ["legacy-draft@1"] },
+        { key: "review", type: "approval_gate", title: "Legacy gate" },
+        { key: "pay", agent: "legacy-payments-agent", skills: ["legacy-post@1"] },
+      ],
+    };
+    const flow = await db.pool.query<{ id: string }>(
+      `INSERT INTO flows (name) VALUES ($1)
+       ON CONFLICT (name) DO UPDATE SET name = EXCLUDED.name RETURNING id`,
+      [def.name],
+    );
+    const fv = await db.pool.query<{ id: string }>(
+      `INSERT INTO flow_versions (flow_id, version, definition, status)
+       VALUES ($1, 1, $2, 'published') RETURNING id`,
+      [flow.rows[0]!.id, JSON.stringify(def)],
+    );
+
+    const runId = await startRun(ctx, { flowVersionId: fv.rows[0]!.id, triggeredBy: USER });
+    await waitForRunStatus(runId, ["waiting_approval"]);
+    const approval = await db.pool.query<{ id: string }>(
+      "SELECT id FROM approvals WHERE run_id = $1 AND status = 'pending'",
+      [runId],
+    );
+    // The requester clears the legacy gate (legacy gates apply no identity rule)…
+    await decideApproval(ctx, {
+      approvalId: approval.rows[0]!.id,
+      decision: "approved",
+      decidedBy: USER,
+    });
+    // …yet the high-risk step is still refused at run time.
+    expect(await waitForRunStatus(runId, ["failed"])).toBe("failed");
+    const { rows } = await db.pool.query<{ payload: { code: string } }>(
+      "SELECT payload FROM audit_events WHERE run_id = $1 AND event_type = 'enforcement.blocked'",
+      [runId],
+    );
+    expect(rows[0]!.payload).toMatchObject({ code: "high_risk_requires_gate" });
   });
 });
 

--- a/packages/server/src/engine/flows.ts
+++ b/packages/server/src/engine/flows.ts
@@ -1,4 +1,5 @@
 import {
+  gateEnforcesSeparation,
   isApprovalGate,
   validateFlowDefinition,
   type FlowDefinition,
@@ -79,19 +80,23 @@ export async function publishFlowVersion(
 }
 
 /**
- * Publish-time risk check: a high-risk skill may only appear in a step that
- * has an approval gate somewhere before it. Skills not yet in the registry
- * are tolerated here (runtime enforcement still denies them by default).
+ * Publish-time risk check: a high-risk skill may only appear in a step that has
+ * a SEPARATION-ENFORCING approval gate somewhere before it — an identity-mode
+ * gate (`approvals` object) that does not disable `forbid_requester`. A legacy
+ * gate proves a human paused, but lets the run's own requester self-approve, so
+ * it cannot guard an irreversible high-risk action (see gateEnforcesSeparation).
+ * Skills not yet in the registry are tolerated here (runtime enforcement still
+ * denies them by default).
  */
 async function validateRiskTiers(pool: Pool, definition: FlowDefinition): Promise<void> {
   const errors: string[] = [];
-  let gateSeen = false;
+  let separationGateSeen = false;
   for (const step of definition.steps) {
     if (isApprovalGate(step)) {
-      gateSeen = true;
+      if (gateEnforcesSeparation(step)) separationGateSeen = true;
       continue;
     }
-    if (gateSeen) continue;
+    if (separationGateSeen) continue;
     for (const ref of step.skills) {
       const { name, version } = parseSkillRef(ref);
       const { rows } = await pool.query<{ risk_tier: string }>(
@@ -100,7 +105,9 @@ async function validateRiskTiers(pool: Pool, definition: FlowDefinition): Promis
       );
       if (rows[0]?.risk_tier === "high") {
         errors.push(
-          `step "${step.key}": skill "${ref}" is high-risk and requires a preceding approval gate`,
+          `step "${step.key}": skill "${ref}" is high-risk and requires a preceding approval ` +
+            "gate that enforces approver separation (an `approvals` object with forbid_requester " +
+            "not disabled), so the run's requester cannot approve their own work",
         );
       }
     }

--- a/packages/server/src/engine/orchestrator.ts
+++ b/packages/server/src/engine/orchestrator.ts
@@ -1,4 +1,5 @@
 import {
+  gateEnforcesSeparation,
   isApprovalGate,
   type AgentStepDef,
   type ApprovalGateApprovalsDef,
@@ -210,7 +211,7 @@ export async function advanceRun(ctx: EngineContext, runId: string): Promise<voi
         agentName: step.agent,
         skillRefs: step.skills,
         runId,
-        hasPrecedingGate: definition.steps.slice(0, nextIndex).some(isApprovalGate),
+        hasSeparationGate: definition.steps.slice(0, nextIndex).some(gateEnforcesSeparation),
       });
     } catch (err) {
       if (err instanceof EnforcementError) {
@@ -300,11 +301,11 @@ export async function advanceRun(ctx: EngineContext, runId: string): Promise<voi
 export async function executeStep(ctx: EngineContext, stepRunId: string): Promise<void> {
   const loaded = await loadStepForExecution(ctx.pool, stepRunId);
   if (!loaded) return; // already handled (idempotency)
-  const { stepRun, step, runId, hasPrecedingGate, meta } = loaded;
+  const { stepRun, step, runId, hasSeparationGate, meta } = loaded;
 
   // Defensive re-enforcement at invocation time: grants or constraints may
   // have changed between scheduling and execution. Deny by default, twice.
-  const blocked = await reEnforce(ctx, { step, runId, stepRunId, hasPrecedingGate });
+  const blocked = await reEnforce(ctx, { step, runId, stepRunId, hasSeparationGate });
   if (blocked) return;
 
   const timeoutMs = step.timeout_ms ?? DEFAULT_STEP_TIMEOUT_MS;
@@ -797,7 +798,7 @@ async function resolveStepInput(client: PoolClient, run: RunRow, stepIndex: numb
 /** Re-runs enforcement at invocation time; returns true if the run was blocked. */
 async function reEnforce(
   ctx: EngineContext,
-  args: { step: AgentStepDef; runId: string; stepRunId: string; hasPrecedingGate: boolean },
+  args: { step: AgentStepDef; runId: string; stepRunId: string; hasSeparationGate: boolean },
 ): Promise<boolean> {
   const client = await ctx.pool.connect();
   try {
@@ -808,7 +809,7 @@ async function reEnforce(
         agentName: args.step.agent,
         skillRefs: args.step.skills,
         runId: args.runId,
-        hasPrecedingGate: args.hasPrecedingGate,
+        hasSeparationGate: args.hasSeparationGate,
       });
       await client.query("COMMIT");
       return false;
@@ -849,7 +850,7 @@ async function loadStepForExecution(
   stepRun: StepRunRow & { agent_id: string };
   step: AgentStepDef;
   runId: string;
-  hasPrecedingGate: boolean;
+  hasSeparationGate: boolean;
   meta: StepExecutionMeta;
 } | null> {
   const { rows } = await pool.query<
@@ -886,7 +887,7 @@ async function loadStepForExecution(
     stepRun,
     step,
     runId: stepRun.run_id,
-    hasPrecedingGate: definition.steps.slice(0, stepRun.step_index).some(isApprovalGate),
+    hasSeparationGate: definition.steps.slice(0, stepRun.step_index).some(gateEnforcesSeparation),
     meta: {
       runId: stepRun.run_id,
       stepRunId: stepRun.id,

--- a/packages/shared/src/flow-definition.test.ts
+++ b/packages/shared/src/flow-definition.test.ts
@@ -1,6 +1,11 @@
 import { describe, expect, it } from "vitest";
 
-import { isApprovalGate, validateFlowDefinition } from "./flow-definition.js";
+import {
+  gateEnforcesSeparation,
+  isApprovalGate,
+  validateFlowDefinition,
+  type FlowStep,
+} from "./flow-definition.js";
 
 const VALID = {
   name: "daily-cash-reconciliation",
@@ -283,5 +288,31 @@ describe("isApprovalGate", () => {
     const ok = validateFlowDefinition(VALID);
     if (!ok.ok) throw new Error("fixture invalid");
     expect(ok.definition.steps.map(isApprovalGate)).toEqual([false, true, false]);
+  });
+});
+
+describe("gateEnforcesSeparation", () => {
+  const gate = (approvals?: Record<string, unknown>): FlowStep =>
+    ({ key: "g", type: "approval_gate", title: "G", ...(approvals ? { approvals } : {}) }) as FlowStep;
+  const agent: FlowStep = { key: "s", agent: "a", skills: ["x@1"] } as FlowStep;
+
+  it("is false for an agent step", () => {
+    expect(gateEnforcesSeparation(agent)).toBe(false);
+  });
+
+  it("is false for a legacy gate (no approvals object — requester could self-approve)", () => {
+    expect(gateEnforcesSeparation(gate())).toBe(false);
+  });
+
+  it("is true for an identity-mode gate (forbid_requester defaults on)", () => {
+    expect(gateEnforcesSeparation(gate({ min_approvals: 1 }))).toBe(true);
+  });
+
+  it("is true when forbid_requester is explicitly true", () => {
+    expect(gateEnforcesSeparation(gate({ forbid_requester: true }))).toBe(true);
+  });
+
+  it("is false when forbid_requester is explicitly disabled", () => {
+    expect(gateEnforcesSeparation(gate({ forbid_requester: false }))).toBe(false);
   });
 });

--- a/packages/shared/src/flow-definition.ts
+++ b/packages/shared/src/flow-definition.ts
@@ -98,6 +98,25 @@ export function isApprovalGate(step: FlowStep): step is ApprovalGateStepDef {
   return "type" in step && step.type === "approval_gate";
 }
 
+/**
+ * A gate "enforces separation" when it can keep the run's own requester from
+ * approving their own work: it is identity-mode (defines an `approvals` object,
+ * which forces decisions to come from an authenticated user) AND does not
+ * explicitly disable `forbid_requester` (which defaults ON in identity mode).
+ *
+ * A legacy gate (no `approvals` object) applies no identity rule and so cannot
+ * satisfy segregation of duties. Any gate type proves "a human paused here";
+ * only a separation-enforcing gate proves "the approver is not the requester" —
+ * which is what a HIGH-RISK step must be guarded by.
+ */
+export function gateEnforcesSeparation(step: FlowStep): boolean {
+  return (
+    isApprovalGate(step) &&
+    step.approvals !== undefined &&
+    step.approvals.forbid_requester !== false
+  );
+}
+
 export type FlowValidationResult =
   | { ok: true; definition: FlowDefinition }
   | { ok: false; errors: string[] };

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -4,6 +4,7 @@ export {
   ApprovalGateApprovals,
   ApprovalGateStep,
   FlowDefinitionSchema,
+  gateEnforcesSeparation,
   isApprovalGate,
   SKILL_REF_PATTERN,
   SkillRef,


### PR DESCRIPTION
## The hole

Self-approval prevention was **opt-in, not a guarantee**. A flow author could place a high-risk skill behind a **legacy** approval gate (a gate with no `approvals` object), trigger the run, and **approve their own irreversible action**:

- `high_risk_requires_gate` was satisfied by *any* gate type (`some(isApprovalGate)`), and
- a legacy gate applies no `forbid_requester` rule, so there was no maker/checker separation.

This contradicts the product's core claim that the run's requester cannot approve their own work.

## The fix

A high-risk skill must be guarded by a **separation-enforcing gate** — an identity-mode gate (`approvals` object) with `forbid_requester` not disabled — enforced at **both** layers:

- **Publish time** (`validateRiskTiers`): a high-risk step behind only a legacy gate is now rejected, so a vulnerable flow can never be published.
- **Run time** (`enforce`): the renamed `hasSeparationGate` signal is computed via a new `gateEnforcesSeparation()` helper, so a flow version published **before** this rule (immutable, still loadable) fails closed when its legacy gate is self-approved.

Legacy gates remain valid for low-risk approvals, where requester self-decision is an intentional open-pool design.

## Tests

- `shared`: unit tests for `gateEnforcesSeparation` (legacy → false, `forbid_requester:false` → false, identity-mode default/explicit → true).
- `server` (adversarial): publish-time rejection of a legacy-gated high-risk skill; run-time fail-closed when the requester self-approves a legacy gate on a flow that predates the rule; updated end-to-end test to the secure identity-mode pattern with a distinct approver.

Full suite green locally: 673 server tests + 48 shared tests pass, coverage thresholds hold, typecheck + lint clean.

## Scope / follow-ups (not in this PR)

This closes the high-risk self-approval path. The audit also flagged, as separate items: admins may decide any gate (admin-who-triggers can self-approve), agent-triggered runs cannot bind `forbid_requester`, and `MAKERCHECKER_AUTH_DISABLED=1` disables decision authz with no bind guard.