### PR TITLE
feat(engine): freeze agent model_config at step scheduling

### DIFF
--- a/docs/concepts.md
+++ b/docs/concepts.md
@@ -8,7 +8,7 @@ An agent is an identity, its role defines what it may do, and nothing is permitt
 
 An identity that executes flow steps.
 
-**Key fields:** `name` (unique), `description`, `role_id` (required, exactly one role), `model_config` (LLM provider/model, optional), `status` (`active` | `suspended` | `retired`).
+**Key fields:** `name` (unique), `description`, `role_id` (required, exactly one role), `model_config` (LLM provider/model, optional; frozen into each step at scheduling, see Snapshot semantics), `status` (`active` | `suspended` | `retired`).
 
 **Invariants:**
 - An agent holds exactly one role. Permissions are never attached to agents directly.
@@ -83,7 +83,7 @@ The v0 grammar (`packages/shared/src/flow-definition.ts`) is frozen: **sequentia
 
 A run is one execution of a flow version. `flow_runs` tracks status (`pending`, `running`, `waiting_approval`, `completed`, `failed`, `cancelled`, `timed_out`), `triggered_by`, `input`, and `failure_reason`. `step_runs` tracks each attempt, with inputs, outputs, and errors.
 
-**Snapshot semantics:** when a step starts, the agent's current role is frozen into `step_runs.role_id_snapshot`. SoD is evaluated against these snapshots, so reassigning an agent's role later cannot rewrite who acted as what in a past run.
+**Snapshot semantics:** when a step is scheduled, the same transaction freezes the agent's current role into `step_runs.role_id_snapshot`, the role's enforced limits into `step_runs.limits_snapshot`, and the agent's `model_config` into `step_runs.model_config_snapshot`. SoD is evaluated against the frozen role, the limit checks read the frozen limits, and the LLM executor runs the frozen model. So reassigning an agent's role, editing `roles.limits`, or changing `agents.model_config` mid-run cannot rewrite who acted as what, widen the ceilings, or swap the model of an already-scheduled step. `limits_snapshot` is frozen once per (run, role) and `model_config_snapshot` once per (run, agent), each carried forward across retries; pre-migration rows with a null snapshot fall back to the live value.
 
 **The audit chain** (`audit_events`) is append-only and hash-chained:
 

--- a/packages/server/migrations/0008_model_config_snapshot.sql
+++ b/packages/server/migrations/0008_model_config_snapshot.sql
@@ -1,0 +1,18 @@
+-- Frozen agent model_config per step attempt.
+--
+-- agents.model_config is mutable working config: an admin can change a step's
+-- provider/model at any time. Reading it LIVE at execution means an admin who
+-- edits model_config between scheduling and execution silently swaps which
+-- model runs an already-scheduled step — the as-run model stops being the
+-- as-approved one, and the audit record (the llm.call payload) no longer
+-- proves which model actually executed.
+--
+-- step_runs.model_config_snapshot freezes the agent's model_config at
+-- scheduling time, alongside role_id_snapshot and limits_snapshot, once per
+-- step attempt (keyed by the agent, since model_config is an agent property).
+-- loadStepForExecution reads this frozen copy and the LLM executor records it,
+-- so a later edit to agents.model_config cannot change which model an in-flight
+-- run uses. Nullable for backward compatibility with step_runs scheduled before
+-- this migration; the loader falls back to live agents.model_config only when
+-- the snapshot is null, never silently changing an in-flight run.
+ALTER TABLE step_runs ADD COLUMN model_config_snapshot jsonb;

--- a/packages/server/src/engine/enforcement.ts
+++ b/packages/server/src/engine/enforcement.ts
@@ -1,5 +1,7 @@
 import type { PoolClient } from "pg";
 
+import type { Json } from "./executor.js";
+
 /**
  * Pre-execution authorization. Called at BOTH decision time (flow.advance)
  * and invocation time (step.execute) — deny by default, twice.
@@ -36,6 +38,8 @@ export interface EnforcedAgent {
   agentId: string;
   agentName: string;
   roleId: string;
+  /** The agent's live model_config, frozen into the step_run at scheduling. */
+  modelConfig: Json;
   skillIds: Record<string, string>; // "name@version" -> skill id
 }
 
@@ -103,8 +107,13 @@ export async function checkSodConflict(
 }
 
 export async function enforce(client: PoolClient, input: EnforceInput): Promise<EnforcedAgent> {
-  const agents = await client.query<{ id: string; role_id: string; status: string }>(
-    "SELECT id, role_id, status FROM agents WHERE name = $1",
+  const agents = await client.query<{
+    id: string;
+    role_id: string;
+    status: string;
+    model_config: Json;
+  }>(
+    "SELECT id, role_id, status, model_config FROM agents WHERE name = $1",
     [input.agentName],
   );
   const agent = agents.rows[0];
@@ -174,6 +183,7 @@ export async function enforce(client: PoolClient, input: EnforceInput): Promise<
     agentId: agent.id,
     agentName: input.agentName,
     roleId: agent.role_id,
+    modelConfig: agent.model_config,
     skillIds,
   };
 }

--- a/packages/server/src/engine/model-config-snapshot.security.test.ts
+++ b/packages/server/src/engine/model-config-snapshot.security.test.ts
@@ -1,0 +1,227 @@
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+
+import { createTestDb, type TestDb } from "../../test/test-db.js";
+import { GraphileWorkerBackend, migrateGraphileWorkerSchema } from "./graphile-backend.js";
+import { LLMExecutor } from "./llm-executor.js";
+import { publishFlowVersion } from "./flows.js";
+import { advanceRun, executeStep, startRun, type EngineContext } from "./orchestrator.js";
+import type { LLMProvider, LLMRequest, LLMTurn } from "../llm/provider.js";
+import { SkillInvoker } from "../skills/invoker.js";
+
+/**
+ * Red-team regression suite for the LIVE MODEL_CONFIG FAIL-OPEN defect: the
+ * agent's model_config was read LIVE from the agents table at execution, so an
+ * admin editing agents.model_config between scheduling and execution silently
+ * swapped which model ran an already-scheduled step. The as-run model must be
+ * the as-approved one: model_config is FROZEN at scheduling
+ * (step_runs.model_config_snapshot) and the executor reads the frozen copy.
+ *
+ * The resolved model is observable in the llm.call audit payload's `model`
+ * field, which is what these tests assert on. A null snapshot (a step_run
+ * scheduled before the migration) must fall back to live model_config.
+ */
+
+let db: TestDb;
+let ctx: EngineContext;
+let provider: RecordingProvider;
+const USER = { type: "user" as const, id: "mc-user", name: "Model Config Tester" };
+
+beforeAll(async () => {
+  db = await createTestDb();
+  // Install the graphile-worker schema (enqueueInTx writes to it) but never
+  // start a worker: these tests drive advanceRun / executeStep BY HAND so the
+  // mid-run edit to agents.model_config lands in the gap between scheduling
+  // (the freeze) and execution (the read). A running worker would race that gap.
+  await migrateGraphileWorkerSchema(db.pool);
+  const backend = new GraphileWorkerBackend(db.pool, 5);
+  provider = new RecordingProvider();
+  const executor = new LLMExecutor({
+    pool: db.pool,
+    providers: { anthropic: provider },
+    invoker: new SkillInvoker(db.pool, new Map()),
+  });
+  ctx = { pool: db.pool, backend, executor };
+}, 60_000);
+
+afterAll(async () => {
+  await db.drop();
+});
+
+/** Scripted provider: returns a single end_turn and records every request. */
+class RecordingProvider implements LLMProvider {
+  requests: LLMRequest[] = [];
+
+  async complete(req: LLMRequest): Promise<LLMTurn> {
+    this.requests.push(req);
+    return {
+      stopReason: "end_turn",
+      content: [{ type: "text", text: "done" }],
+      usage: { inputTokens: 1, outputTokens: 1 },
+    };
+  }
+}
+
+async function seedAgent(name: string, model: string): Promise<string> {
+  const { rows } = await db.pool.query<{ id: string }>(
+    `WITH role AS (INSERT INTO roles (name) VALUES ($1) RETURNING id)
+     INSERT INTO agents (name, role_id, model_config)
+     SELECT $2, id, $3 FROM role RETURNING id`,
+    [`${name}-role`, name, JSON.stringify({ provider: "anthropic", model })],
+  );
+  return rows[0]!.id;
+}
+
+/** A granted skill so enforcement passes; the model ends without calling it. */
+async function seedGrantedSkill(agentName: string, ref: string): Promise<void> {
+  const [name, version] = ref.split("@");
+  await db.pool.query(
+    `INSERT INTO skills (name, version, input_schema, output_schema, implementation, risk_tier)
+     VALUES ($1, $2, '{}', '{}', '{"type":"local"}', 'low') ON CONFLICT DO NOTHING`,
+    [name, Number(version)],
+  );
+  await db.pool.query(
+    `INSERT INTO role_skill_grants (role_id, skill_id)
+     SELECT a.role_id, s.id FROM agents a, skills s
+      WHERE a.name = $1 AND s.name = $2 AND s.version = $3`,
+    [agentName, name, Number(version)],
+  );
+}
+
+async function setLiveModelConfig(agentId: string, model: string): Promise<void> {
+  await db.pool.query("UPDATE agents SET model_config = $2 WHERE id = $1", [
+    agentId,
+    JSON.stringify({ provider: "anthropic", model }),
+  ]);
+}
+
+/** A one-step LLM flow whose model ends the turn without calling the skill. */
+async function publishSingleStep(
+  flowName: string,
+  agentName: string,
+  skillRef: string,
+): Promise<string> {
+  const { flowVersionId } = await publishFlowVersion(db.pool, {
+    actor: USER,
+    definition: {
+      name: flowName,
+      steps: [{ key: "s", agent: agentName, skills: [skillRef], instructions: "Work." }],
+    },
+  });
+  return flowVersionId;
+}
+
+async function pendingStepRunId(runId: string): Promise<string> {
+  const { rows } = await db.pool.query<{ id: string }>(
+    "SELECT id FROM step_runs WHERE run_id = $1 ORDER BY id DESC LIMIT 1",
+    [runId],
+  );
+  return rows[0]!.id;
+}
+
+async function llmCallModels(runId: string): Promise<string[]> {
+  const { rows } = await db.pool.query<{ payload: { model: string } }>(
+    "SELECT payload FROM audit_events WHERE run_id = $1 AND event_type = 'llm.call' ORDER BY seq",
+    [runId],
+  );
+  return rows.map((r) => r.payload.model);
+}
+
+describe("model_config is frozen at scheduling, not read live at execution", () => {
+  it("editing agents.model_config between scheduling and execution does NOT change the model", async () => {
+    const agentId = await seedAgent("freeze-agent", "claude-opus-4-8");
+    await seedGrantedSkill("freeze-agent", "noop@1");
+    const flowVersionId = await publishSingleStep("freeze-flow", "freeze-agent", "noop@1");
+
+    // startRun enqueues the first advance, but we drive advanceRun ourselves so
+    // the step is scheduled (and its model_config frozen) right here.
+    const runId = await startRun(ctx, { flowVersionId, triggeredBy: USER });
+    await advanceRun(ctx, runId);
+    const stepRunId = await pendingStepRunId(runId);
+
+    // The frozen copy was taken at scheduling; the live row is now wide open.
+    const frozen = await db.pool.query<{ model_config_snapshot: { model: string } }>(
+      "SELECT model_config_snapshot FROM step_runs WHERE id = $1",
+      [stepRunId],
+    );
+    expect(frozen.rows[0]!.model_config_snapshot.model).toBe("claude-opus-4-8");
+
+    // Admin swaps the live model AFTER scheduling, BEFORE execution.
+    await setLiveModelConfig(agentId, "attacker-model");
+
+    await executeStep(ctx, stepRunId);
+
+    // The as-run model is the frozen one, never the live "attacker-model".
+    expect(await llmCallModels(runId)).toEqual(["claude-opus-4-8"]);
+    const live = await db.pool.query<{ model_config: { model: string } }>(
+      "SELECT model_config FROM agents WHERE id = $1",
+      [agentId],
+    );
+    expect(live.rows[0]!.model_config.model).toBe("attacker-model");
+  });
+
+  it("a RETRY re-uses the frozen model, not the model changed between attempts", async () => {
+    const agentId = await seedAgent("retry-model-agent", "claude-opus-4-8");
+    await seedGrantedSkill("retry-model-agent", "noop@1");
+    const { flowVersionId } = await publishFlowVersion(db.pool, {
+      actor: USER,
+      definition: {
+        name: "retry-model-flow",
+        steps: [
+          {
+            key: "s",
+            agent: "retry-model-agent",
+            skills: ["noop@1"],
+            instructions: "Work.",
+            retries: { max_attempts: 2, backoff: "none" },
+          },
+        ],
+      },
+    });
+
+    const runId = await startRun(ctx, { flowVersionId, triggeredBy: USER });
+    // Attempt 1 schedules and freezes opus.
+    await advanceRun(ctx, runId);
+    const attempt1 = await pendingStepRunId(runId);
+    // Admin swaps the live model; then attempt 1 fails to force a retry.
+    await setLiveModelConfig(agentId, "attacker-model");
+    await db.pool.query(
+      "UPDATE step_runs SET status = 'failed', finished_at = now() WHERE id = $1",
+      [attempt1],
+    );
+    // Attempt 2 schedules: it must carry attempt 1's frozen model, not the live one.
+    await advanceRun(ctx, runId);
+
+    const snaps = await db.pool.query<{ model_config_snapshot: { model: string } }>(
+      "SELECT model_config_snapshot FROM step_runs WHERE run_id = $1 ORDER BY attempt",
+      [runId],
+    );
+    expect(snaps.rows.length).toBe(2);
+    for (const row of snaps.rows) {
+      expect(row.model_config_snapshot.model).toBe("claude-opus-4-8");
+    }
+  });
+
+  it("a null snapshot (pre-migration row) falls back to live model_config", async () => {
+    const agentId = await seedAgent("fallback-agent", "claude-opus-4-8");
+    await seedGrantedSkill("fallback-agent", "noop@1");
+    const flowVersionId = await publishSingleStep("fallback-flow", "fallback-agent", "noop@1");
+    const runId = await startRun(ctx, { flowVersionId, triggeredBy: USER });
+
+    // Insert a step_run by hand WITHOUT a model_config_snapshot (genuinely NULL,
+    // not '{}'), exactly as a row scheduled before migration 0008 would look.
+    const inserted = await db.pool.query<{ id: string }>(
+      `INSERT INTO step_runs
+         (run_id, step_index, step_key, agent_id, role_id_snapshot, status, attempt, input, started_at)
+       SELECT $1, 0, 's', $2, a.role_id, 'running', 1, '{}', now()
+         FROM agents a WHERE a.id = $2 RETURNING id`,
+      [runId, agentId],
+    );
+    await db.pool.query("UPDATE flow_runs SET status = 'running' WHERE id = $1", [runId]);
+
+    // The live row is the only source for a null snapshot — set it to a known model.
+    await setLiveModelConfig(agentId, "live-fallback-model");
+    await executeStep(ctx, inserted.rows[0]!.id);
+
+    expect(await llmCallModels(runId)).toEqual(["live-fallback-model"]);
+  });
+});

--- a/packages/server/src/engine/orchestrator.ts
+++ b/packages/server/src/engine/orchestrator.ts
@@ -259,10 +259,25 @@ export async function advanceRun(ctx: EngineContext, runId: string): Promise<voi
     const limitsSnapshot =
       frozen.rows[0]?.limits_snapshot ?? (await getRoleLimits(client, enforced.roleId));
 
+    // Freeze the agent's model_config ONCE per (run, agent), carried forward
+    // across retries and later steps on the same agent. model_config is an
+    // agent property, so a retry re-uses the original frozen model rather than
+    // re-reading whatever agents.model_config is NOW — an admin editing the
+    // agent mid-run cannot swap the model of an already-scheduled step. Read
+    // live (enforced.modelConfig) only on the agent's first appearance.
+    const frozenModel = await client.query<{ model_config_snapshot: Json }>(
+      `SELECT model_config_snapshot FROM step_runs
+        WHERE run_id = $1 AND agent_id = $2 AND model_config_snapshot IS NOT NULL
+        ORDER BY started_at ASC NULLS FIRST, attempt ASC, id ASC LIMIT 1`,
+      [runId, enforced.agentId],
+    );
+    const modelConfigSnapshot =
+      frozenModel.rows[0]?.model_config_snapshot ?? enforced.modelConfig;
+
     const stepRun = await client.query<{ id: string }>(
       `INSERT INTO step_runs
-         (run_id, step_index, step_key, agent_id, role_id_snapshot, limits_snapshot, status, attempt, input, started_at)
-       VALUES ($1, $2, $3, $4, $5, $6, 'running', $7, $8, now()) RETURNING id`,
+         (run_id, step_index, step_key, agent_id, role_id_snapshot, limits_snapshot, model_config_snapshot, status, attempt, input, started_at)
+       VALUES ($1, $2, $3, $4, $5, $6, $7, 'running', $8, $9, now()) RETURNING id`,
       [
         runId,
         nextIndex,
@@ -270,6 +285,7 @@ export async function advanceRun(ctx: EngineContext, runId: string): Promise<voi
         enforced.agentId,
         enforced.roleId,
         JSON.stringify(limitsSnapshot),
+        JSON.stringify(modelConfigSnapshot),
         attempt,
         JSON.stringify(stepInput),
       ],
@@ -864,14 +880,18 @@ async function loadStepForExecution(
     StepRunRow & {
       agent_id: string;
       role_id_snapshot: string;
+      model_config_snapshot: Json | null;
       flow_version_id: string;
       agent_name: string;
       model_config: Json;
     }
   >(
+    // Read the FROZEN model_config taken at scheduling; fall back to the live
+    // a.model_config only when the snapshot is null (step_runs scheduled before
+    // migration 0008), never silently swapping the model of an in-flight run.
     `SELECT sr.id, sr.run_id, sr.step_index, sr.step_key, sr.status, sr.attempt, sr.input,
-            sr.agent_id, sr.role_id_snapshot, fr.flow_version_id, a.name AS agent_name,
-            a.model_config
+            sr.agent_id, sr.role_id_snapshot, sr.model_config_snapshot,
+            fr.flow_version_id, a.name AS agent_name, a.model_config
        FROM step_runs sr
        JOIN flow_runs fr ON fr.id = sr.run_id
        JOIN agents a ON a.id = sr.agent_id
@@ -901,7 +921,7 @@ async function loadStepForExecution(
       agentId: stepRun.agent_id,
       agentName: stepRun.agent_name,
       roleId: stepRun.role_id_snapshot,
-      modelConfig: stepRun.model_config,
+      modelConfig: stepRun.model_config_snapshot ?? stepRun.model_config,
     },
   };
 }


### PR DESCRIPTION
## Why

`model_config` is read LIVE at execution today (`loadStepForExecution` joins `agents` and returns `a.model_config`). An admin editing an agent's model/provider between scheduling and execution silently changes which model runs an already-scheduled step, so the as-run model is not provably the as-approved one — exactly the evidence an audited agentic system must produce. Role limits already close this gap via `limits_snapshot`; `model_config` did not.

## What

Freezes the agent's `model_config` at scheduling, mirroring `limits_snapshot` exactly — backward-compatible and fail-safe.

- **Migration `0008_model_config_snapshot.sql`** — nullable `step_runs.model_config_snapshot jsonb`, doc-comment in the `0006` style. Nullable so rows scheduled before this migration fall back to the live value.
- **`enforce()`** selects `agents.model_config` and returns it on `EnforcedAgent.modelConfig`, making it available inside the advisory-locked scheduling transaction.
- **Scheduling** — the single `INSERT INTO step_runs` writes `model_config_snapshot` in the same transaction as `role_id_snapshot`/`limits_snapshot`, frozen once per `(run, agent)` and carried forward across retries (a retry re-uses the original frozen model rather than re-reading the live row).
- **Execution** — `loadStepForExecution` uses `model_config_snapshot ?? a.model_config`, falling back to live only when the snapshot is null. The LLM executor is unchanged and still records the resolved model in the `llm.call` audit payload.
- **`docs/concepts.md`** — `model_config_snapshot` documented alongside `role_id_snapshot` and `limits_snapshot` in *Snapshot semantics*.

## Tests

New `model-config-snapshot.security.test.ts` drives the real orchestrator (an `LLMExecutor` with a recording provider) and asserts the as-run model on the `llm.call` payload:

- Editing `agents.model_config` between scheduling and execution does NOT change the model the already-scheduled step uses.
- A retry re-uses the frozen model, not one changed between attempts.
- A null snapshot (a pre-migration row) falls back to live `model_config`.

712 tests pass; 90% coverage thresholds hold; lint and typecheck clean.