### PR TITLE
ci: add SBOM generation and container image CVE scan

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -98,6 +98,74 @@ jobs:
         if: always()
         run: docker compose down -v
 
+  # Image CVE scan (Layer 2, base-image side): pnpm audit at `security` only sees
+  # the npm dependency tree. The shipped artifact also carries Alpine OS packages
+  # from node:22-alpine — trivy is what catches a high/critical CVE in those that
+  # the npm audit cannot. ignore-unfixed keeps the gate honest: node:22-alpine
+  # routinely ships base CVEs with no upstream fix, and gating on those would pin
+  # the build permanently red and block every unrelated PR until a base bump that
+  # may not exist. So this fails ONLY on a HIGH/CRITICAL that actually has a fix.
+  image-scan:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      # Each job runs on a fresh runner with no shared local image, and the
+      # `docker` job above tears its image down. Build our own with an explicit
+      # tag (context is the repo root: the Dockerfile COPYs package manifests,
+      # the workspace packages, and examples/ relative to it) so trivy has a
+      # predictable reference instead of the compose-derived name.
+      - name: Build server image
+        run: docker build -t makerchecker-server:ci -f packages/server/Dockerfile .
+      - name: Trivy image scan (gate on fixable HIGH/CRITICAL)
+        uses: aquasecurity/trivy-action@v0.36.0
+        with:
+          image-ref: makerchecker-server:ci
+          scan-type: image
+          format: table
+          exit-code: "1"
+          ignore-unfixed: true
+          severity: HIGH,CRITICAL
+          vuln-type: os,library
+
+  # SBOM (evidence, non-gating): emit a machine-readable CycloneDX bill of
+  # materials a self-hosting regulated buyer can ingest. This generates and
+  # uploads evidence — it must never fail the PR, so there is no exit-code here
+  # (sbom-action does not fail on findings). syft reads both the OS and JS layers
+  # of the actual shipped image, plus the full source dependency tree.
+  sbom:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      # Build the image so the SBOM reflects exactly what ships (pruned prod
+      # node_modules + Alpine OS packages), not just what is in the repo.
+      - name: Build server image
+        run: docker build -t makerchecker-server:ci -f packages/server/Dockerfile .
+      # upload-artifact is disabled on each sbom-action step so the action does
+      # not auto-upload twice under the same name (upload-artifact@v4 errors on a
+      # duplicate name); a single consolidated upload below controls the name.
+      - name: Generate CycloneDX SBOM (image)
+        uses: anchore/sbom-action@v0
+        with:
+          image: makerchecker-server:ci
+          format: cyclonedx-json
+          output-file: sbom-image.cdx.json
+          upload-artifact: false
+      - name: Generate CycloneDX SBOM (source tree)
+        uses: anchore/sbom-action@v0
+        with:
+          path: .
+          format: cyclonedx-json
+          output-file: sbom-source.cdx.json
+          upload-artifact: false
+      # if-no-files-found: error so a silently-empty SBOM (e.g. a bad output-file
+      # path) fails the job loudly instead of uploading nothing.
+      - name: Upload SBOM artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: sbom
+          path: sbom-*.cdx.json
+          if-no-files-found: error
+
   # The Python SDK is outside the pnpm/turbo workspace, so it gets its own lane:
   # lint (ruff), strict types (mypy), and tests (pytest, no server needed).
   python-sdk:

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -39,6 +39,7 @@ MakerChecker is built for regulated, adversarial-insider environments. The harde
 - **SSRF and DNS rebinding are blocked on every outbound path** (skill fetch, webhooks, MCP transport) by static host validation plus connect-time IP pinning. Leave `MAKERCHECKER_ALLOW_PRIVATE_SKILL_HOSTS` unset in production.
 - **Demo seeding is opt-in.** With `MAKERCHECKER_SEED_DEMO` unset, no admin account or admin API key is created.
 - **Role limits fail closed.** Limits are schema-validated (non-coercing) at write time and pinned per `(run, role)`; the runtime denies any limit it cannot interpret.
+- **Ship with a CycloneDX SBOM and a scanned image.** CI emits a machine-readable SBOM of the shipped server image and its dependency tree as a build artifact, and scans the image for known CVEs; the scan gates on fixable high/critical findings so a self-hosting deployment can audit what it runs.
 
 ## Auditing the audit chain
 

--- a/packages/server/Dockerfile
+++ b/packages/server/Dockerfile
@@ -15,6 +15,9 @@ RUN pnpm --filter @makerchecker/server... run build && \
 
 FROM node:22-alpine
 WORKDIR /app
+# Drop the bundled npm/npx CLI: the runtime runs node directly (pnpm/corepack are
+# build-time only), so npm is unused weight whose vendored deps trip the image scan.
+RUN rm -rf /usr/local/lib/node_modules/npm /usr/local/bin/npm /usr/local/bin/npx
 ENV NODE_ENV=production
 ENV DEMO_DATA_DIR=/app/examples/daily-cash-reconciliation
 ENV MAKERCHECKER_WEB_DIST=/app/web-dist


### PR DESCRIPTION
Adds two jobs to `.github/workflows/ci.yml` so a self-hosting regulated buyer gets a machine-readable bill of materials and the shipped image is scanned for known CVEs. Both build the server image from the repo-root context the Dockerfile requires.

## `image-scan` (new gate)
Runs `aquasecurity/trivy-action@v0.28.0` against the built image with `ignore-unfixed: true`, `severity: HIGH,CRITICAL`, `exit-code: "1"`, `vuln-type: os,library`.

- Fails **only** on a HIGH/CRITICAL CVE that has a fix available — unfixable `node:22-alpine` base advisories are reported but do not pin the build red.
- Catches OS-package CVEs in the shipped artifact that the existing `pnpm audit` (npm tree only) cannot.

## `sbom` (non-gating evidence)
Runs `anchore/sbom-action@v0` to emit CycloneDX JSON for both the built image and the source dependency tree, uploaded as a single `sbom` artifact via `actions/upload-artifact@v4`. No `exit-code`, so it generates evidence and never fails the PR.

## `SECURITY.md`
One bullet noting the SBOM artifact and image scan.

## Reliability
Self-verifying via this PR's own CI. Gates only on fixable findings (base image can't pin it red); builds the image before scanning; inline trivy gating + a plain artifact upload, so it works regardless of repo visibility. YAML validated; jobs are `checks`, `security`, `docker`, `image-scan`, `sbom`, `python-sdk`.