### PR TITLE
chore(server): run container non-root, pin base, add healthcheck

### DIFF
--- a/docker-compose.hardened.yml
+++ b/docker-compose.hardened.yml
@@ -106,6 +106,15 @@ services:
       - mcdata:/data
     ports:
       - "3000:3000"
+    # Least-privilege runtime: the server needs no Linux capabilities and must
+    # never gain privileges, so a code-exec bug cannot escalate. read_only is
+    # left off because the stdio MCP-skill path spawns npx/uvx, which writes
+    # caches under /tmp and ~/.npm outside the /data volume; enabling it needs a
+    # paired /tmp tmpfs and a writable HOME, exercised separately.
+    cap_drop:
+      - ALL
+    security_opt:
+      - "no-new-privileges:true"
     depends_on:
       postgres:
         condition: service_healthy

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -49,6 +49,15 @@ services:
       - mcdata:/data
     ports:
       - "3000:3000"
+    # Least-privilege runtime: the server needs no Linux capabilities and must
+    # never gain privileges, so a code-exec bug cannot escalate. read_only is
+    # left off because the stdio MCP-skill path spawns npx/uvx, which writes
+    # caches under /tmp and ~/.npm outside the /data volume; enabling it needs a
+    # paired /tmp tmpfs and a writable HOME, exercised separately.
+    cap_drop:
+      - ALL
+    security_opt:
+      - "no-new-privileges:true"
     depends_on:
       postgres:
         condition: service_healthy

--- a/packages/server/Dockerfile
+++ b/packages/server/Dockerfile
@@ -1,4 +1,6 @@
-FROM node:22-alpine AS build
+# Digest-pinned so a moved tag cannot swap the base out from under a build;
+# Dependabot/Renovate bumps the digest as upstream re-publishes.
+FROM node:22-alpine@sha256:e58326d0d441090181ac150dc2078d3e2cf6a0d42e809aebba3ef5880935ffdd AS build
 WORKDIR /repo
 RUN corepack enable
 COPY package.json pnpm-workspace.yaml pnpm-lock.yaml turbo.json tsconfig.base.json ./
@@ -13,7 +15,7 @@ RUN pnpm --filter @makerchecker/server... run build && \
     pnpm --filter @makerchecker/web run build && \
     pnpm --filter @makerchecker/server deploy --prod /app
 
-FROM node:22-alpine
+FROM node:22-alpine@sha256:e58326d0d441090181ac150dc2078d3e2cf6a0d42e809aebba3ef5880935ffdd
 WORKDIR /app
 # Drop the bundled npm/npx CLI: the runtime runs node directly (pnpm/corepack are
 # build-time only), so npm is unused weight whose vendored deps trip the image scan.
@@ -21,8 +23,19 @@ RUN rm -rf /usr/local/lib/node_modules/npm /usr/local/bin/npm /usr/local/bin/npx
 ENV NODE_ENV=production
 ENV DEMO_DATA_DIR=/app/examples/daily-cash-reconciliation
 ENV MAKERCHECKER_WEB_DIST=/app/web-dist
-COPY --from=build /app /app
-COPY --from=build /repo/packages/web/dist /app/web-dist
-COPY examples /app/examples
+COPY --from=build --chown=node:node /app /app
+COPY --from=build --chown=node:node /repo/packages/web/dist /app/web-dist
+COPY --chown=node:node examples /app/examples
+# Run as the unprivileged built-in `node` user (uid 1000) so the runtime cannot
+# write outside its data dir and passes non-root PodSecurity. The signing key is
+# written under MAKERCHECKER_DATA_DIR; pre-own both the /data mount target and
+# the default ./data (=/app/data) so a fresh named volume inherits node on first
+# mount and the key write does not hit EACCES.
+RUN mkdir -p /data /app/data && chown -R node:node /data /app
+# Probe the real app route, not a static asset; busybox wget is the only HTTP
+# client in the base image (no curl). /healthz is auth- and rate-limit-exempt.
+HEALTHCHECK --interval=10s --timeout=3s --start-period=20s --retries=5 \
+  CMD wget -qO- http://127.0.0.1:3000/healthz || exit 1
+USER node
 EXPOSE 3000
 CMD ["node", "dist/index.js"]


### PR DESCRIPTION
Harden the server runtime container for bank PodSecurity without breaking the audit signing-key write or the CI docker boot gate.

## Dockerfile (`packages/server/Dockerfile`)
- Run the final stage as the `node:22-alpine` built-in non-root `node` user (uid 1000). The runtime writes its Ed25519 signing key to `MAKERCHECKER_DATA_DIR`, so `/data` (and the bare-run default `/app/data`) are created and `chown`ed to `node:node` **before** `USER node` — a fresh `mcdata` named volume inherits node ownership on first mount, so the key write doesn't `EACCES`. App layers copied `--chown=node:node`.
- Pin both `FROM node:22-alpine` lines to `@sha256:…` so a moved tag can't swap the base out from under a build; Dependabot/Renovate bumps the digest.
- Add a `HEALTHCHECK` hitting `/healthz` via busybox `wget` (alpine has no curl), portable across orchestrators.

## Compose (`docker-compose.yml`, `docker-compose.hardened.yml`)
- `cap_drop: [ALL]` + `security_opt: ["no-new-privileges:true"]` on the server service in both files.
- `read_only` deferred: the stdio MCP-skill path spawns npx/uvx, which writes outside `/data` (`/tmp`, `~/.npm`); a read-only rootfs needs a paired `/tmp` tmpfs + writable HOME. Tracked as a follow-up.

No app source changed.

## Verification
Booted locally (the equivalent of the CI `docker` job): `docker compose up -d --build`, polled `/healthz` → `{"status":"ok","schemaVersion":1}`, **first attempt**. Confirmed `id` → `uid=1000(node)`, `/data` is `node:node` on a fresh volume, the node user writes + reads back `instance_key.pem` at `0600`, and the Dockerfile HEALTHCHECK reports `healthy`. Independently re-verified by review.

## Upgrade note
A pre-existing `mcdata` volume created by a **root** run keeps root ownership and would `EACCES` under the new non-root user. On upgrade, recreate it (`docker compose down -v`) or one-time `chown -R 1000:1000` the volume.