### PR TITLE
feat(web): writable roles, grants, and SoD admin controls

### DIFF
--- a/packages/web/src/components/RoleControls.test.tsx
+++ b/packages/web/src/components/RoleControls.test.tsx
@@ -1,0 +1,263 @@
+import { screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { roleDetail, roles, skills } from "../../test/fixtures";
+import { renderApp } from "../../test/render";
+import * as api from "../lib/api";
+
+vi.mock("../lib/api", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../lib/api")>();
+  return {
+    ...actual,
+    listRoles: vi.fn(),
+    getRole: vi.fn(),
+    listSkills: vi.fn(),
+    createRole: vi.fn(),
+    createGrant: vi.fn(),
+    revokeGrant: vi.fn(),
+    createSodConstraint: vi.fn(),
+    revokeSodConstraint: vi.fn(),
+  };
+});
+
+const mocked = {
+  listRoles: vi.mocked(api.listRoles),
+  getRole: vi.mocked(api.getRole),
+  listSkills: vi.mocked(api.listSkills),
+  createRole: vi.mocked(api.createRole),
+  createGrant: vi.mocked(api.createGrant),
+  revokeGrant: vi.mocked(api.revokeGrant),
+  createSodConstraint: vi.mocked(api.createSodConstraint),
+  revokeSodConstraint: vi.mocked(api.revokeSodConstraint),
+};
+
+const SECOND_ROLE: api.RoleSummary = {
+  id: "ro2",
+  name: "recon-approver-role",
+  description: "Approves reconciliations",
+  limits: {},
+  created_at: "2026-06-01T00:00:00.000Z",
+  active_grant_count: 0,
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mocked.listRoles.mockResolvedValue({ roles: [roles[0]!, SECOND_ROLE] });
+  mocked.getRole.mockResolvedValue(roleDetail);
+  mocked.listSkills.mockResolvedValue({ skills });
+});
+
+describe("CreateRoleForm", () => {
+  it("requires a name before calling the api", async () => {
+    renderApp("/roles");
+    await userEvent.click(await screen.findByRole("button", { name: "Create role" }));
+    expect(screen.getByText("A role name is required.")).toBeDefined();
+    expect(mocked.createRole).not.toHaveBeenCalled();
+  });
+
+  it("creates a role and navigates to its detail page", async () => {
+    mocked.createRole.mockResolvedValue({
+      role: {
+        id: "ro-new",
+        name: "payments-role",
+        description: "moves money",
+        limits: {},
+        created_at: "2026-06-17T00:00:00.000Z",
+      },
+    });
+    const { router } = renderApp("/roles");
+
+    await userEvent.type(await screen.findByLabelText("Role name"), "payments-role");
+    await userEvent.type(screen.getByLabelText("Role description"), "moves money");
+    await userEvent.click(screen.getByRole("button", { name: "Create role" }));
+
+    expect(mocked.createRole).toHaveBeenCalledWith({
+      name: "payments-role",
+      description: "moves money",
+    });
+    await waitFor(() => expect(router.state.location.pathname).toBe("/roles/ro-new"));
+  });
+
+  it("surfaces the server error inline without crashing", async () => {
+    mocked.createRole.mockRejectedValue(
+      new api.ApiError(409, JSON.stringify({ error: 'role "payments-role" already exists' })),
+    );
+    renderApp("/roles");
+
+    await userEvent.type(await screen.findByLabelText("Role name"), "payments-role");
+    await userEvent.click(screen.getByRole("button", { name: "Create role" }));
+
+    expect(await screen.findByText('role "payments-role" already exists')).toBeDefined();
+    expect(screen.getByRole("button", { name: "Create role" })).toBeDefined();
+  });
+});
+
+describe("AddGrantForm", () => {
+  it("requires a skill selection", async () => {
+    renderApp("/roles/ro1");
+    await userEvent.click(await screen.findByRole("button", { name: "Grant skill" }));
+    expect(screen.getByText("Choose a skill to grant.")).toBeDefined();
+    expect(mocked.createGrant).not.toHaveBeenCalled();
+  });
+
+  it("grants a skill with the role and skill ids and refetches", async () => {
+    mocked.createGrant.mockResolvedValue({
+      grant: {
+        id: "g-new",
+        role_id: "ro1",
+        skill_id: "sk2",
+        created_at: "2026-06-17T00:00:00.000Z",
+        revoked_at: null,
+      },
+    });
+    renderApp("/roles/ro1");
+
+    await screen.findByRole("option", { name: /approve-recon@2/ });
+    await userEvent.selectOptions(screen.getByLabelText("Skill to grant"), "sk2");
+    await userEvent.click(screen.getByRole("button", { name: "Grant skill" }));
+
+    expect(mocked.createGrant).toHaveBeenCalledWith("ro1", "sk2");
+    await waitFor(() => expect(mocked.getRole.mock.calls.length).toBeGreaterThan(1));
+  });
+
+  it("surfaces a duplicate-grant conflict inline", async () => {
+    mocked.createGrant.mockRejectedValue(
+      new api.ApiError(409, JSON.stringify({ error: "an active identical grant already exists" })),
+    );
+    renderApp("/roles/ro1");
+
+    await screen.findByRole("option", { name: /csv-ingest@1/ });
+    await userEvent.selectOptions(screen.getByLabelText("Skill to grant"), "sk1");
+    await userEvent.click(screen.getByRole("button", { name: "Grant skill" }));
+
+    expect(await screen.findByText("an active identical grant already exists")).toBeDefined();
+  });
+});
+
+describe("RevokeGrantButton", () => {
+  it("revokes an active grant after confirming and refetches", async () => {
+    mocked.revokeGrant.mockResolvedValue({
+      grant: {
+        id: "g1",
+        role_id: "ro1",
+        skill_id: "sk1",
+        created_at: "2026-06-01T00:00:00.000Z",
+        revoked_at: "2026-06-17T00:00:00.000Z",
+      },
+    });
+    renderApp("/roles/ro1");
+
+    // The active grant (g1) renders the first Revoke control on the page.
+    const revokeButtons = await screen.findAllByRole("button", { name: "Revoke" });
+    await userEvent.click(revokeButtons[0]!);
+    await userEvent.click(screen.getByRole("button", { name: "Confirm revoke" }));
+
+    expect(mocked.revokeGrant).toHaveBeenCalledWith("g1");
+    await waitFor(() => expect(mocked.getRole.mock.calls.length).toBeGreaterThan(1));
+  });
+
+  it("surfaces an already-revoked conflict inline", async () => {
+    mocked.revokeGrant.mockRejectedValue(
+      new api.ApiError(409, JSON.stringify({ error: "grant already revoked" })),
+    );
+    renderApp("/roles/ro1");
+
+    const revokeButtons = await screen.findAllByRole("button", { name: "Revoke" });
+    await userEvent.click(revokeButtons[0]!);
+    await userEvent.click(screen.getByRole("button", { name: "Confirm revoke" }));
+
+    expect(await screen.findByText("grant already revoked")).toBeDefined();
+  });
+});
+
+describe("AddSodForm", () => {
+  it("requires the other role", async () => {
+    renderApp("/roles/ro1");
+    await userEvent.click(await screen.findByRole("button", { name: "Add SoD constraint" }));
+    expect(screen.getByText("Choose the other role.")).toBeDefined();
+    expect(mocked.createSodConstraint).not.toHaveBeenCalled();
+  });
+
+  it("creates a SoD constraint against another role", async () => {
+    mocked.createSodConstraint.mockResolvedValue({
+      sodConstraint: {
+        id: "sc-new",
+        role_a_id: "ro1",
+        role_b_id: "ro2",
+        description: "no self-approval",
+        created_at: "2026-06-17T00:00:00.000Z",
+        revoked_at: null,
+      },
+    });
+    renderApp("/roles/ro1");
+
+    await screen.findByRole("option", { name: "recon-approver-role" });
+    await userEvent.selectOptions(screen.getByLabelText("Other role"), "ro2");
+    await userEvent.type(
+      screen.getByLabelText("Constraint description"),
+      "no self-approval",
+    );
+    await userEvent.click(screen.getByRole("button", { name: "Add SoD constraint" }));
+
+    expect(mocked.createSodConstraint).toHaveBeenCalledWith({
+      roleAId: "ro1",
+      roleBId: "ro2",
+      description: "no self-approval",
+    });
+    await waitFor(() => expect(mocked.getRole.mock.calls.length).toBeGreaterThan(1));
+  });
+
+  it("surfaces a self-constraint error inline", async () => {
+    mocked.createSodConstraint.mockRejectedValue(
+      new api.ApiError(
+        400,
+        JSON.stringify({ error: "a role cannot be SoD-constrained against itself" }),
+      ),
+    );
+    renderApp("/roles/ro1");
+
+    await screen.findByRole("option", { name: "recon-approver-role" });
+    await userEvent.selectOptions(screen.getByLabelText("Other role"), "ro2");
+    await userEvent.click(screen.getByRole("button", { name: "Add SoD constraint" }));
+
+    expect(
+      await screen.findByText("a role cannot be SoD-constrained against itself"),
+    ).toBeDefined();
+  });
+});
+
+describe("RevokeSodButton", () => {
+  it("revokes an active constraint after confirming", async () => {
+    mocked.revokeSodConstraint.mockResolvedValue({
+      sodConstraint: {
+        id: "sc1",
+        role_a_id: "ro1",
+        role_b_id: "ro2",
+        description: null,
+        created_at: "2026-06-01T00:00:00.000Z",
+        revoked_at: "2026-06-17T00:00:00.000Z",
+      },
+    });
+    renderApp("/roles/ro1");
+
+    // The active constraint (sc1) is the first Revoke control on the page.
+    const revokeButtons = await screen.findAllByRole("button", { name: "Revoke" });
+    await userEvent.click(revokeButtons[revokeButtons.length - 1]!);
+    await userEvent.click(screen.getByRole("button", { name: "Confirm revoke" }));
+
+    expect(mocked.revokeSodConstraint).toHaveBeenCalledWith("sc1");
+    await waitFor(() => expect(mocked.getRole.mock.calls.length).toBeGreaterThan(1));
+  });
+
+  it("can be cancelled without calling the api", async () => {
+    renderApp("/roles/ro1");
+
+    const revokeButtons = await screen.findAllByRole("button", { name: "Revoke" });
+    await userEvent.click(revokeButtons[revokeButtons.length - 1]!);
+    await userEvent.click(screen.getByRole("button", { name: "Cancel" }));
+
+    expect(screen.queryByRole("button", { name: "Confirm revoke" })).toBeNull();
+    expect(mocked.revokeSodConstraint).not.toHaveBeenCalled();
+  });
+});

--- a/packages/web/src/components/RoleControls.tsx
+++ b/packages/web/src/components/RoleControls.tsx
@@ -1,0 +1,306 @@
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { useNavigate } from "@tanstack/react-router";
+import { useState } from "react";
+
+import {
+  apiErrorMessage,
+  createGrant,
+  createRole,
+  createSodConstraint,
+  listRoles,
+  listSkills,
+  revokeGrant,
+  revokeSodConstraint,
+} from "../lib/api";
+
+const inputClass = "w-full rounded border border-line bg-paper px-2.5 py-1.5 text-sm";
+const affirmBtn =
+  "rounded border border-verified bg-verified px-3 py-1.5 text-xs font-medium text-white disabled:opacity-50";
+const destructiveBtn =
+  "rounded border border-blocked bg-white px-3 py-1.5 text-xs font-medium text-blocked disabled:opacity-50";
+
+function MutationError({ error }: { error: unknown }) {
+  return (
+    <p className="mt-1 text-xs font-medium text-blocked" role="alert">
+      {apiErrorMessage(error)}
+    </p>
+  );
+}
+
+/** Create a role, then navigate to its detail page so grants can be added. */
+export function CreateRoleForm() {
+  const queryClient = useQueryClient();
+  const navigate = useNavigate();
+  const [name, setName] = useState("");
+  const [description, setDescription] = useState("");
+  const [validationError, setValidationError] = useState<string | null>(null);
+
+  const mut = useMutation({
+    mutationFn: () =>
+      createRole({
+        name: name.trim(),
+        ...(description.trim() === "" ? {} : { description: description.trim() }),
+      }),
+    onSuccess: async (res) => {
+      await queryClient.invalidateQueries({ queryKey: ["roles"] });
+      setName("");
+      setDescription("");
+      void navigate({ to: "/roles/$roleId", params: { roleId: res.role.id } });
+    },
+  });
+
+  const submit = () => {
+    if (name.trim() === "") {
+      setValidationError("A role name is required.");
+      return;
+    }
+    setValidationError(null);
+    mut.mutate();
+  };
+
+  return (
+    <div className="mt-3 max-w-md space-y-2">
+      <input
+        value={name}
+        onChange={(e) => setName(e.target.value)}
+        placeholder="Role name (e.g. recon-approver-role)"
+        aria-label="Role name"
+        className={inputClass}
+      />
+      <textarea
+        value={description}
+        onChange={(e) => setDescription(e.target.value)}
+        placeholder="Description (optional)"
+        aria-label="Role description"
+        rows={2}
+        className={inputClass}
+      />
+      {validationError && (
+        <p className="text-xs font-medium text-blocked" role="alert">
+          {validationError}
+        </p>
+      )}
+      {mut.isError && <MutationError error={mut.error} />}
+      <button type="button" disabled={mut.isPending} onClick={submit} className={affirmBtn}>
+        Create role
+      </button>
+    </div>
+  );
+}
+
+/** Grant a skill to a role: pick a published skill, POST /grants, refresh the detail. */
+export function AddGrantForm({ roleId }: { roleId: string }) {
+  const queryClient = useQueryClient();
+  const skillsQuery = useQuery({ queryKey: ["skills"], queryFn: listSkills });
+  const [skillId, setSkillId] = useState("");
+  const [validationError, setValidationError] = useState<string | null>(null);
+
+  const mut = useMutation({
+    mutationFn: () => createGrant(roleId, skillId),
+    onSuccess: async () => {
+      await queryClient.invalidateQueries({ queryKey: ["role", roleId] });
+      await queryClient.invalidateQueries({ queryKey: ["roles"] });
+      setSkillId("");
+    },
+  });
+
+  const submit = () => {
+    if (skillId === "") {
+      setValidationError("Choose a skill to grant.");
+      return;
+    }
+    setValidationError(null);
+    mut.mutate();
+  };
+
+  const skills = skillsQuery.data?.skills ?? [];
+
+  return (
+    <div className="mt-3 flex flex-wrap items-center gap-2">
+      <select
+        value={skillId}
+        onChange={(e) => setSkillId(e.target.value)}
+        aria-label="Skill to grant"
+        className={`${inputClass} max-w-xs`}
+      >
+        <option value="">Select a skill…</option>
+        {skills.map((skill) => (
+          <option key={skill.id} value={skill.id}>
+            {skill.name}@{skill.version} ({skill.risk_tier} risk)
+          </option>
+        ))}
+      </select>
+      <button type="button" disabled={mut.isPending} onClick={submit} className={affirmBtn}>
+        Grant skill
+      </button>
+      {validationError && (
+        <p className="w-full text-xs font-medium text-blocked" role="alert">
+          {validationError}
+        </p>
+      )}
+      {mut.isError && (
+        <div className="w-full">
+          <MutationError error={mut.error} />
+        </div>
+      )}
+    </div>
+  );
+}
+
+/** A two-step inline revoke control — no DELETE, grants are revoked, never deleted. */
+export function RevokeGrantButton({ roleId, grantId }: { roleId: string; grantId: string }) {
+  const queryClient = useQueryClient();
+  const [confirming, setConfirming] = useState(false);
+
+  const mut = useMutation({
+    mutationFn: () => revokeGrant(grantId),
+    onSuccess: async () => {
+      await queryClient.invalidateQueries({ queryKey: ["role", roleId] });
+      await queryClient.invalidateQueries({ queryKey: ["roles"] });
+      setConfirming(false);
+    },
+  });
+
+  if (!confirming) {
+    return (
+      <button
+        type="button"
+        onClick={() => setConfirming(true)}
+        className="text-xs font-medium text-blocked underline-offset-2 hover:underline"
+      >
+        Revoke
+      </button>
+    );
+  }
+
+  return (
+    <span className="inline-flex flex-wrap items-center gap-2">
+      <button type="button" disabled={mut.isPending} onClick={() => mut.mutate()} className={destructiveBtn}>
+        Confirm revoke
+      </button>
+      <button
+        type="button"
+        disabled={mut.isPending}
+        onClick={() => setConfirming(false)}
+        className="text-xs font-medium text-stone-500 underline-offset-2 hover:underline"
+      >
+        Cancel
+      </button>
+      {mut.isError && <MutationError error={mut.error} />}
+    </span>
+  );
+}
+
+/** Add a SoD constraint between this role and another. */
+export function AddSodForm({ roleId, roleName }: { roleId: string; roleName: string }) {
+  const queryClient = useQueryClient();
+  const rolesQuery = useQuery({ queryKey: ["roles"], queryFn: listRoles });
+  const [otherRoleId, setOtherRoleId] = useState("");
+  const [description, setDescription] = useState("");
+  const [validationError, setValidationError] = useState<string | null>(null);
+
+  const mut = useMutation({
+    mutationFn: () =>
+      createSodConstraint({
+        roleAId: roleId,
+        roleBId: otherRoleId,
+        ...(description.trim() === "" ? {} : { description: description.trim() }),
+      }),
+    onSuccess: async () => {
+      await queryClient.invalidateQueries({ queryKey: ["role", roleId] });
+      setOtherRoleId("");
+      setDescription("");
+    },
+  });
+
+  const submit = () => {
+    if (otherRoleId === "") {
+      setValidationError("Choose the other role.");
+      return;
+    }
+    setValidationError(null);
+    mut.mutate();
+  };
+
+  const otherRoles = (rolesQuery.data?.roles ?? []).filter((r) => r.id !== roleId);
+
+  return (
+    <div className="mt-3 max-w-md space-y-2">
+      <p className="text-xs text-stone-500">
+        Constrain {roleName} against another role so no actor can hold both on one run.
+      </p>
+      <select
+        value={otherRoleId}
+        onChange={(e) => setOtherRoleId(e.target.value)}
+        aria-label="Other role"
+        className={inputClass}
+      >
+        <option value="">Select the other role…</option>
+        {otherRoles.map((role) => (
+          <option key={role.id} value={role.id}>
+            {role.name}
+          </option>
+        ))}
+      </select>
+      <input
+        value={description}
+        onChange={(e) => setDescription(e.target.value)}
+        placeholder="Description (optional)"
+        aria-label="Constraint description"
+        className={inputClass}
+      />
+      {validationError && (
+        <p className="text-xs font-medium text-blocked" role="alert">
+          {validationError}
+        </p>
+      )}
+      {mut.isError && <MutationError error={mut.error} />}
+      <button type="button" disabled={mut.isPending} onClick={submit} className={affirmBtn}>
+        Add SoD constraint
+      </button>
+    </div>
+  );
+}
+
+/** Two-step inline revoke for a SoD constraint. */
+export function RevokeSodButton({ roleId, constraintId }: { roleId: string; constraintId: string }) {
+  const queryClient = useQueryClient();
+  const [confirming, setConfirming] = useState(false);
+
+  const mut = useMutation({
+    mutationFn: () => revokeSodConstraint(constraintId),
+    onSuccess: async () => {
+      await queryClient.invalidateQueries({ queryKey: ["role", roleId] });
+      setConfirming(false);
+    },
+  });
+
+  if (!confirming) {
+    return (
+      <button
+        type="button"
+        onClick={() => setConfirming(true)}
+        className="text-xs font-medium text-blocked underline-offset-2 hover:underline"
+      >
+        Revoke
+      </button>
+    );
+  }
+
+  return (
+    <span className="mt-1 inline-flex flex-wrap items-center gap-2">
+      <button type="button" disabled={mut.isPending} onClick={() => mut.mutate()} className={destructiveBtn}>
+        Confirm revoke
+      </button>
+      <button
+        type="button"
+        disabled={mut.isPending}
+        onClick={() => setConfirming(false)}
+        className="text-xs font-medium text-stone-500 underline-offset-2 hover:underline"
+      >
+        Cancel
+      </button>
+      {mut.isError && <MutationError error={mut.error} />}
+    </span>
+  );
+}

--- a/packages/web/src/lib/api.test.ts
+++ b/packages/web/src/lib/api.test.ts
@@ -2,6 +2,10 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 
 import {
   ApiError,
+  apiErrorMessage,
+  createGrant,
+  createRole,
+  createSodConstraint,
   decideApproval,
   getAgent,
   getApiKey,
@@ -16,6 +20,8 @@ import {
   listRoles,
   listRuns,
   listSkills,
+  revokeGrant,
+  revokeSodConstraint,
   setApiKey,
   triggerFlow,
   UNAUTHORIZED_EVENT,
@@ -191,6 +197,101 @@ describe("endpoints", () => {
     const fn2 = mockFetch(200, { flow: { id: "f1" }, versions: [] });
     await getFlow("daily-cash-reconciliation");
     expect(lastCall(fn2).url).toBe("/api/flows/daily-cash-reconciliation");
+  });
+});
+
+describe("access-control mutations", () => {
+  const ROLE_A = "11111111-1111-1111-1111-111111111111";
+  const ROLE_B = "22222222-2222-2222-2222-222222222222";
+  const SKILL = "33333333-3333-3333-3333-333333333333";
+
+  it("creates a role with only a name", async () => {
+    const fn = mockFetch(201, { role: { id: "ro9" } });
+    const res = await createRole({ name: "recon-approver-role" });
+    expect(res.role.id).toBe("ro9");
+    const { url, init } = lastCall(fn);
+    expect(url).toBe("/api/roles");
+    expect(init.method).toBe("POST");
+    expect(JSON.parse(init.body as string)).toEqual({ name: "recon-approver-role" });
+  });
+
+  it("creates a role with description and limits", async () => {
+    const fn = mockFetch(201, { role: { id: "ro9" } });
+    await createRole({
+      name: "payments-role",
+      description: "moves money",
+      limits: { run: { maxTokens: 1000 } },
+    });
+    expect(JSON.parse(lastCall(fn).init.body as string)).toEqual({
+      name: "payments-role",
+      description: "moves money",
+      limits: { run: { maxTokens: 1000 } },
+    });
+  });
+
+  it("creates a grant with roleId and skillId", async () => {
+    const fn = mockFetch(201, { grant: { id: "g9" } });
+    await createGrant(ROLE_A, SKILL);
+    const { url, init } = lastCall(fn);
+    expect(url).toBe("/api/grants");
+    expect(init.method).toBe("POST");
+    expect(JSON.parse(init.body as string)).toEqual({ roleId: ROLE_A, skillId: SKILL });
+  });
+
+  it("revokes a grant by grant id with no body", async () => {
+    const fn = mockFetch(200, { grant: { id: "g9", revoked_at: "now" } });
+    await revokeGrant("g 9");
+    const { url, init } = lastCall(fn);
+    expect(url).toBe("/api/grants/g%209/revoke");
+    expect(init.method).toBe("POST");
+    expect(init.body).toBeUndefined();
+  });
+
+  it("creates a SoD constraint with the role ids", async () => {
+    const fn = mockFetch(201, { sodConstraint: { id: "sc9" } });
+    await createSodConstraint({ roleAId: ROLE_A, roleBId: ROLE_B, description: "no self-approval" });
+    const { url, init } = lastCall(fn);
+    expect(url).toBe("/api/sod-constraints");
+    expect(JSON.parse(init.body as string)).toEqual({
+      roleAId: ROLE_A,
+      roleBId: ROLE_B,
+      description: "no self-approval",
+    });
+  });
+
+  it("omits description from a SoD body when not given", async () => {
+    const fn = mockFetch(201, { sodConstraint: { id: "sc9" } });
+    await createSodConstraint({ roleAId: ROLE_A, roleBId: ROLE_B });
+    expect(JSON.parse(lastCall(fn).init.body as string)).toEqual({
+      roleAId: ROLE_A,
+      roleBId: ROLE_B,
+    });
+  });
+
+  it("revokes a SoD constraint by constraint id", async () => {
+    const fn = mockFetch(200, { sodConstraint: { id: "sc9" } });
+    await revokeSodConstraint("sc9");
+    const { url, init } = lastCall(fn);
+    expect(url).toBe("/api/sod-constraints/sc9/revoke");
+    expect(init.method).toBe("POST");
+    expect(init.body).toBeUndefined();
+  });
+});
+
+describe("apiErrorMessage", () => {
+  it("unwraps a JSON { error } body from an ApiError", () => {
+    const err = new ApiError(403, JSON.stringify({ error: "admin privileges required" }));
+    expect(apiErrorMessage(err)).toBe("admin privileges required");
+  });
+
+  it("falls back to the message for a non-JSON ApiError body", () => {
+    const err = new ApiError(500, "<html>boom</html>");
+    expect(apiErrorMessage(err)).toContain("500");
+  });
+
+  it("handles plain errors and non-errors", () => {
+    expect(apiErrorMessage(new Error("local"))).toBe("local");
+    expect(apiErrorMessage("raw string")).toBe("raw string");
   });
 });
 

--- a/packages/web/src/lib/api.ts
+++ b/packages/web/src/lib/api.ts
@@ -19,6 +19,25 @@ export class ApiError extends Error {
   }
 }
 
+/**
+ * The human-readable message for a failed request. The server sends JSON
+ * `{ error: "..." }` bodies but `request` stores the raw text, so `ApiError`'s
+ * own message is the JSON-wrapped form. This unwraps it: an `ApiError` whose
+ * body parses to `{ error }` surfaces the bare server string (e.g.
+ * "admin privileges required"); anything else falls back to the error message.
+ */
+export function apiErrorMessage(error: unknown): string {
+  if (error instanceof ApiError) {
+    try {
+      const parsed = JSON.parse(error.body) as { error?: unknown };
+      if (typeof parsed.error === "string") return parsed.error;
+    } catch {
+      /* not JSON — fall through */
+    }
+  }
+  return error instanceof Error ? error.message : String(error);
+}
+
 export function getApiKey(): string | null {
   return localStorage.getItem(API_KEY_STORAGE);
 }
@@ -337,6 +356,74 @@ export function listRoles(): Promise<{ roles: RoleSummary[] }> {
 
 export function getRole(id: string): Promise<RoleDetail> {
   return request(`/roles/${encodeURIComponent(id)}`);
+}
+
+export interface CreatedRole {
+  id: string;
+  name: string;
+  description: string;
+  limits: Record<string, unknown>;
+  created_at: string;
+}
+
+export function createRole(input: {
+  name: string;
+  description?: string;
+  limits?: Record<string, unknown>;
+}): Promise<{ role: CreatedRole }> {
+  const body: Record<string, unknown> = { name: input.name };
+  if (input.description !== undefined) body.description = input.description;
+  if (input.limits !== undefined) body.limits = input.limits;
+  return request("/roles", { method: "POST", body: JSON.stringify(body) });
+}
+
+export interface CreatedGrant {
+  id: string;
+  role_id: string;
+  skill_id: string;
+  created_at: string;
+  revoked_at: string | null;
+}
+
+export function createGrant(roleId: string, skillId: string): Promise<{ grant: CreatedGrant }> {
+  return request("/grants", {
+    method: "POST",
+    body: JSON.stringify({ roleId, skillId }),
+  });
+}
+
+export function revokeGrant(grantId: string): Promise<{ grant: CreatedGrant }> {
+  return request(`/grants/${encodeURIComponent(grantId)}/revoke`, { method: "POST" });
+}
+
+export interface CreatedSodConstraint {
+  id: string;
+  role_a_id: string;
+  role_b_id: string;
+  description: string | null;
+  created_at: string;
+  revoked_at: string | null;
+}
+
+export function createSodConstraint(input: {
+  roleAId: string;
+  roleBId: string;
+  description?: string;
+}): Promise<{ sodConstraint: CreatedSodConstraint }> {
+  const body: Record<string, unknown> = {
+    roleAId: input.roleAId,
+    roleBId: input.roleBId,
+  };
+  if (input.description !== undefined) body.description = input.description;
+  return request("/sod-constraints", { method: "POST", body: JSON.stringify(body) });
+}
+
+export function revokeSodConstraint(
+  constraintId: string,
+): Promise<{ sodConstraint: CreatedSodConstraint }> {
+  return request(`/sod-constraints/${encodeURIComponent(constraintId)}/revoke`, {
+    method: "POST",
+  });
 }
 
 export function listFlows(): Promise<{ flows: FlowSummary[] }> {

--- a/packages/web/src/pages/RolesPage.tsx
+++ b/packages/web/src/pages/RolesPage.tsx
@@ -2,6 +2,13 @@ import { useQuery } from "@tanstack/react-query";
 import { Link, useParams } from "@tanstack/react-router";
 
 import {
+  AddGrantForm,
+  AddSodForm,
+  CreateRoleForm,
+  RevokeGrantButton,
+  RevokeSodButton,
+} from "../components/RoleControls";
+import {
   EmptyNote,
   ErrorNote,
   Loading,
@@ -47,6 +54,11 @@ export function RolesPage() {
           ))}
         </tbody>
       </table>
+
+      <h2 className="mt-10 text-[11px] font-medium uppercase tracking-[0.1em] text-stone-400">
+        Create a role
+      </h2>
+      <CreateRoleForm />
     </div>
   );
 }
@@ -77,15 +89,18 @@ export function RoleDetailPage() {
               <span className="text-xs text-stone-500">
                 granted <RelTime iso={grant.granted_at} />
               </span>
-              {grant.revoked_at && (
+              {grant.revoked_at ? (
                 <span className="text-xs font-medium text-blocked">
                   revoked <RelTime iso={grant.revoked_at} />
                 </span>
+              ) : (
+                <RevokeGrantButton roleId={roleId} grantId={grant.id} />
               )}
             </li>
           ))}
         </ul>
       )}
+      <AddGrantForm roleId={roleId} />
 
       <h2 className="mt-8 text-[11px] font-medium uppercase tracking-[0.1em] text-stone-400">
         Segregation-of-duties constraints
@@ -108,10 +123,14 @@ export function RoleDetailPage() {
                 {constraint.revoked_at && <span className="ml-2">(revoked)</span>}
               </p>
               <p className="mt-0.5 text-xs">{constraint.description}</p>
+              {!constraint.revoked_at && (
+                <RevokeSodButton roleId={roleId} constraintId={constraint.id} />
+              )}
             </li>
           ))}
         </ul>
       )}
+      <AddSodForm roleId={roleId} roleName={role.name} />
     </div>
   );
 }


### PR DESCRIPTION
The admin SPA's access-control surfaces were read-only — administering roles, grants, and segregation-of-duties constraints meant hand-crafted curl against the admin API. This adds the write controls directly in `packages/web`, on the existing `/roles` and `/roles/$roleId` routes.

**In scope:** create role, create grant, revoke grant, create SoD constraint, revoke SoD constraint.
**Follow-up (not built):** agents create/status, skills publish/deprecate, flows publish, triggers, user/API-key management.

## Changes
- **`lib/api.ts`** — five typed POST wrappers reusing the existing `request<T>()` helper:
  - `createRole({ name, description?, limits? })` → `POST /roles`
  - `createGrant(roleId, skillId)` → `POST /grants`
  - `revokeGrant(grantId)` → `POST /grants/:id/revoke`
  - `createSodConstraint({ roleAId, roleBId, description? })` → `POST /sod-constraints`
  - `revokeSodConstraint(constraintId)` → `POST /sod-constraints/:id/revoke`

  Bodies match the server TypeBox shapes exactly (both grant routes take UUIDs, not a skill ref; SoD takes `roleAId`+`roleBId`; revokes carry no body). `additionalProperties:false` server-side, so optional fields are omitted when absent. Adds `apiErrorMessage()` to unwrap the server `{ error }` body and surface the bare message.
- **`components/RoleControls.tsx`** (new) — create-role, add/revoke-grant, add/revoke-SoD. Each `useMutation` + invalidates `['role', roleId]`/`['roles']` on success. A failed mutation renders the server message inline (`role="alert"`) and never crashes the page, so a non-admin's `403` surfaces gracefully. Revokes are two-step inline confirms (the model is revoke-forever; no modal primitive in `ui.tsx`).
- **`pages/RolesPage.tsx`** — wires the controls into the existing routes. No new route.

## Tests
`api.test.ts` asserts URL/method/body for all five wrappers + the error-unwrap; `RoleControls.test.tsx` (new) adds a component test per mutation (required-field validation, correct args, success refetch, inline error for 409/400/403). **184 web tests pass; coverage holds (RoleControls 100%, api.ts 100%); typecheck, lint, build green.**