### PR TITLE
feat(server): graceful shutdown and /readyz readiness probe

### DIFF
--- a/packages/server/src/api/admin.integration.test.ts
+++ b/packages/server/src/api/admin.integration.test.ts
@@ -130,6 +130,12 @@ describe("auth hook", () => {
     expect(res.statusCode).toBe(200);
   });
 
+  it("leaves /readyz open and ready against a live DB", async () => {
+    const res = await app.inject({ method: "GET", url: "/readyz" });
+    expect(res.statusCode).toBe(200);
+    expect(res.json()).toEqual({ status: "ok", schemaVersion: 1 });
+  });
+
   it("skips auth entirely in MAKERCHECKER_AUTH_DISABLED=1 mode; actor falls back to 'api'", async () => {
     process.env.MAKERCHECKER_AUTH_DISABLED = "1";
     try {

--- a/packages/server/src/app.test.ts
+++ b/packages/server/src/app.test.ts
@@ -5,6 +5,7 @@ import { afterEach, describe, expect, it } from "vitest";
 
 import { buildApp } from "./app.js";
 import { loggerOptions } from "./boot/logger.js";
+import { beginShutdown, resetShutdownState } from "./boot/lifecycle.js";
 import type { EngineContext } from "./engine/orchestrator.js";
 
 /**
@@ -43,6 +44,67 @@ describe("GET /healthz", () => {
     const app = await buildApp();
     const res = await app.inject({ method: "GET", url: "/nope" });
     expect(res.statusCode).toBe(404);
+    await app.close();
+  });
+});
+
+describe("GET /readyz", () => {
+  const okCtx = {
+    pool: { query: async () => ({ rows: [{ "?column?": 1 }] }) },
+  } as unknown as EngineContext;
+
+  afterEach(() => {
+    resetShutdownState();
+  });
+
+  it("returns 200 with the schema version when ready and the DB answers", async () => {
+    const app = await buildApp(okCtx);
+    const res = await app.inject({ method: "GET", url: "/readyz" });
+    expect(res.statusCode).toBe(200);
+    expect(res.json()).toEqual({ status: "ok", schemaVersion: 1 });
+    await app.close();
+  });
+
+  it("returns 503 while shutting down, before pinging the DB", async () => {
+    const queried = { hit: false };
+    const drainingCtx = {
+      pool: {
+        query: async () => {
+          queried.hit = true;
+          return { rows: [] };
+        },
+      },
+    } as unknown as EngineContext;
+    const app = await buildApp(drainingCtx);
+    beginShutdown();
+    const res = await app.inject({ method: "GET", url: "/readyz" });
+    expect(res.statusCode).toBe(503);
+    expect(res.json()).toEqual({ status: "shutting_down" });
+    expect(queried.hit).toBe(false);
+    await app.close();
+  });
+
+  it("returns 503 when the DB ping throws", async () => {
+    const downCtx = {
+      pool: {
+        query: async () => {
+          throw new Error("connect ECONNREFUSED 10.0.3.5:5432");
+        },
+      },
+    } as unknown as EngineContext;
+    const app = await buildApp(downCtx);
+    const res = await app.inject({ method: "GET", url: "/readyz" });
+    expect(res.statusCode).toBe(503);
+    expect(res.json()).toEqual({ status: "db_unreachable" });
+    // The infra detail in the thrown error never reaches the client body.
+    expect(res.body).not.toContain("ECONNREFUSED");
+    await app.close();
+  });
+
+  it("stays open under the /api auth hook (no key required)", async () => {
+    const app = await buildApp(okCtx);
+    const res = await app.inject({ method: "GET", url: "/readyz" });
+    expect(res.statusCode).toBe(200);
     await app.close();
   });
 });

--- a/packages/server/src/app.ts
+++ b/packages/server/src/app.ts
@@ -12,6 +12,7 @@ import { actorOf, authDisabled, registerAdminRoutes, requireAdmin } from "./api/
 import { registerProxyRoutes } from "./api/proxy-routes.js";
 import { authenticateApiKey, type AuthUser } from "./auth/api-keys.js";
 import { verifyChain } from "./audit/verify.js";
+import { isShuttingDown } from "./boot/lifecycle.js";
 import { loggerOptions } from "./boot/logger.js";
 import { strictSod } from "./config.js";
 import {
@@ -199,7 +200,7 @@ export async function buildApp(
       timeWindow: "1 minute",
       allowList: (req) => {
         const path = (req.url ?? "").split("?")[0];
-        return path === "/healthz" || path === "/metrics";
+        return path === "/healthz" || path === "/readyz" || path === "/metrics";
       },
     });
     app.addHook("onRequest", app.rateLimit());
@@ -220,6 +221,26 @@ export async function buildApp(
   if (webDist) await registerWebStatic(app, webDist);
 
   if (!ctx) return app;
+
+  // Readiness, distinct from /healthz liveness: 503 while draining (so a rolling
+  // deploy pulls this pod before it stops accepting) or when a bounded SELECT 1
+  // fails. Open like /healthz (root scope, allow-listed). Liveness stays green
+  // when the DB is down so the orchestrator does not restart a healthy process.
+  app.get(
+    "/readyz",
+    { schema: { operationId: "ready", tags: ["meta"] } },
+    async (_req, reply) => {
+      if (isShuttingDown()) {
+        return reply.status(503).send({ status: "shutting_down" });
+      }
+      try {
+        await ctx.pool.query("SELECT 1");
+      } catch {
+        return reply.status(503).send({ status: "db_unreachable" });
+      }
+      return reply.status(200).send({ status: "ok", schemaVersion: SCHEMA_VERSION });
+    },
+  );
 
   // Prometheus exposition at the root (outside /api, no auth) — scrapers live
   // inside the deployment perimeter, so exposing it is an explicit operator

--- a/packages/server/src/boot/lifecycle.test.ts
+++ b/packages/server/src/boot/lifecycle.test.ts
@@ -1,0 +1,137 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import {
+  beginShutdown,
+  gracefulShutdown,
+  isShuttingDown,
+  resetShutdownLatch,
+  resetShutdownState,
+  type ShutdownDeps,
+} from "./lifecycle.js";
+
+const silentLogger = { info: () => {}, error: () => {} };
+
+function makeDeps(over: Partial<ShutdownDeps> = {}): { deps: ShutdownDeps; order: string[] } {
+  const order: string[] = [];
+  const deps: ShutdownDeps = {
+    app: { close: vi.fn(async () => void order.push("app.close")) },
+    backend: { stop: vi.fn(async () => void order.push("backend.stop")) },
+    pool: { end: vi.fn(async () => void order.push("pool.end")) },
+    watchdog: setInterval(() => {}, 1_000),
+    logger: silentLogger,
+    ...over,
+  } as ShutdownDeps;
+  return { deps, order };
+}
+
+afterEach(() => {
+  resetShutdownState();
+  resetShutdownLatch();
+});
+
+describe("shutdown flag", () => {
+  it("defaults to false and flips on beginShutdown", () => {
+    expect(isShuttingDown()).toBe(false);
+    beginShutdown();
+    expect(isShuttingDown()).toBe(true);
+  });
+});
+
+describe("gracefulShutdown", () => {
+  it("tears down in dependency-reverse order with the pool last", async () => {
+    const { deps, order } = makeDeps();
+    const cleared = vi.spyOn(globalThis, "clearInterval");
+
+    await gracefulShutdown(deps, { timeoutMs: 5_000 });
+
+    expect(order).toEqual(["app.close", "backend.stop", "pool.end"]);
+    expect(cleared).toHaveBeenCalledWith(deps.watchdog);
+    expect(isShuttingDown()).toBe(true);
+    cleared.mockRestore();
+  });
+
+  it("sets the readiness flag before any teardown runs", async () => {
+    let flagDuringClose: boolean | undefined;
+    const { deps } = makeDeps({
+      app: { close: vi.fn(async () => void (flagDuringClose = isShuttingDown())) },
+    });
+
+    await gracefulShutdown(deps, { timeoutMs: 5_000 });
+
+    expect(flagDuringClose).toBe(true);
+  });
+
+  it("is idempotent: a second call does not re-run teardown", async () => {
+    const { deps } = makeDeps();
+
+    await gracefulShutdown(deps, { timeoutMs: 5_000 });
+    await gracefulShutdown(deps, { timeoutMs: 5_000 });
+
+    expect(deps.app.close).toHaveBeenCalledTimes(1);
+    expect(deps.backend.stop).toHaveBeenCalledTimes(1);
+    expect(deps.pool.end).toHaveBeenCalledTimes(1);
+  });
+
+  it("joins a concurrent second call to the in-flight drain", async () => {
+    const { deps } = makeDeps();
+    const first = gracefulShutdown(deps, { timeoutMs: 5_000 });
+    const second = gracefulShutdown(deps, { timeoutMs: 5_000 });
+    await Promise.all([first, second]);
+    expect(deps.pool.end).toHaveBeenCalledTimes(1);
+  });
+
+  it("continues teardown when an earlier step throws (best-effort)", async () => {
+    const { deps, order } = makeDeps({
+      app: {
+        close: vi.fn(async () => {
+          throw new Error("close boom");
+        }),
+      },
+    });
+
+    await gracefulShutdown(deps, { timeoutMs: 5_000 });
+
+    expect(order).toEqual(["backend.stop", "pool.end"]);
+    expect(deps.pool.end).toHaveBeenCalledTimes(1);
+  });
+
+  it("logs a failed step without aborting", async () => {
+    const errored = vi.fn();
+    const { deps } = makeDeps({
+      logger: { info: () => {}, error: errored },
+      backend: {
+        stop: vi.fn(async () => {
+          throw new Error("stop boom");
+        }),
+      },
+    });
+
+    await gracefulShutdown(deps, { timeoutMs: 5_000 });
+
+    expect(errored).toHaveBeenCalled();
+    expect(deps.pool.end).toHaveBeenCalledTimes(1);
+  });
+
+  it("resolves on the hard timeout when a step hangs forever", async () => {
+    vi.useFakeTimers();
+    try {
+      const { deps } = makeDeps({
+        backend: { stop: vi.fn(() => new Promise<void>(() => {})) },
+      });
+      const errored = vi.fn();
+      deps.logger = { info: () => {}, error: errored };
+
+      const done = gracefulShutdown(deps, { timeoutMs: 25_000 });
+      await vi.advanceTimersByTimeAsync(25_000);
+      await done;
+
+      expect(errored).toHaveBeenCalledWith(
+        expect.objectContaining({ timeoutMs: 25_000 }),
+        expect.stringMatching(/timed out/),
+      );
+      expect(deps.pool.end).not.toHaveBeenCalled();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+});

--- a/packages/server/src/boot/lifecycle.ts
+++ b/packages/server/src/boot/lifecycle.ts
@@ -1,0 +1,96 @@
+import type { FastifyInstance } from "fastify";
+import type { Pool } from "pg";
+import type { Logger } from "pino";
+
+import type { ExecutionBackend } from "../engine/backend.js";
+
+/** Hard cap on the whole drain so a stuck job or hung close can never block exit. */
+const DEFAULT_SHUTDOWN_TIMEOUT_MS = 25_000;
+
+let shuttingDown = false;
+
+/** True once shutdown has begun. The /readyz probe reads this to return 503. */
+export function isShuttingDown(): boolean {
+  return shuttingDown;
+}
+
+/** Flip the drain flag so /readyz starts reporting 503 before teardown runs. */
+export function beginShutdown(): void {
+  shuttingDown = true;
+}
+
+/** Reset the flag. For tests only — the live process never un-shuts. */
+export function resetShutdownState(): void {
+  shuttingDown = false;
+}
+
+export interface ShutdownDeps {
+  app: Pick<FastifyInstance, "close">;
+  backend: Pick<ExecutionBackend, "stop">;
+  pool: Pick<Pool, "end">;
+  /** The watchdog setInterval handle, captured at boot so it can be cleared. */
+  watchdog: ReturnType<typeof setInterval>;
+  logger: Pick<Logger, "info" | "error">;
+}
+
+export interface ShutdownOptions {
+  timeoutMs?: number;
+}
+
+let inFlight: Promise<void> | null = null;
+
+async function runStep(
+  logger: Pick<Logger, "error">,
+  label: string,
+  step: () => Promise<void> | void,
+): Promise<void> {
+  try {
+    await step();
+  } catch (err) {
+    logger.error({ step: label, err: { message: (err as Error).message } }, "shutdown step failed");
+  }
+}
+
+async function drain(deps: ShutdownDeps): Promise<void> {
+  await runStep(deps.logger, "app.close", () => deps.app.close());
+  await runStep(deps.logger, "backend.stop", () => deps.backend.stop());
+  await runStep(deps.logger, "clearInterval", () => clearInterval(deps.watchdog));
+  await runStep(deps.logger, "pool.end", () => deps.pool.end());
+}
+
+/**
+ * Drain in-flight work in dependency-reverse order: flip readiness to 503, stop
+ * accepting and finish open HTTP requests (app.close), drain queued jobs
+ * (backend.stop), stop the watchdog, then close the pool LAST — both the app and
+ * the backend query through the pool while draining. Each step is best-effort:
+ * a failure is logged, never fatal. A second call (double SIGTERM) joins the
+ * first. A hard timeout forces resolution so a hung drain cannot block exit.
+ */
+export async function gracefulShutdown(
+  deps: ShutdownDeps,
+  opts?: ShutdownOptions,
+): Promise<void> {
+  if (inFlight) return inFlight;
+  beginShutdown();
+  const timeoutMs = opts?.timeoutMs ?? DEFAULT_SHUTDOWN_TIMEOUT_MS;
+  deps.logger.info({ timeoutMs }, "graceful shutdown starting");
+
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  const guard = new Promise<void>((resolve) => {
+    timer = setTimeout(() => {
+      deps.logger.error({ timeoutMs }, "graceful shutdown timed out; forcing exit");
+      resolve();
+    }, timeoutMs);
+    timer.unref?.();
+  });
+
+  inFlight = Promise.race([drain(deps).finally(() => clearTimeout(timer)), guard]).then(() => {
+    deps.logger.info("graceful shutdown complete");
+  });
+  return inFlight;
+}
+
+/** Reset the in-flight latch. For tests only. */
+export function resetShutdownLatch(): void {
+  inFlight = null;
+}

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -1,6 +1,7 @@
 import { buildApp } from "./app.js";
 import { assertAuthBindSafe } from "./boot/bind-guard.js";
 import { createCronTriggerHandler, loadCronItems, TASK_CRON_TRIGGER } from "./boot/cron.js";
+import { gracefulShutdown } from "./boot/lifecycle.js";
 import { workerLogger } from "./boot/logger.js";
 import { emitRedactionDisabledWarning } from "./boot/redaction-warning.js";
 import { migrate } from "./db/migrate.js";
@@ -96,7 +97,7 @@ async function main(): Promise<void> {
   // Watchdog: recover steps orphaned by crashed workers and flag approvals
   // pending past the overdue threshold. A sweep failure is logged, never
   // fatal — the next tick tries again.
-  setInterval(() => {
+  const watchdog = setInterval(() => {
     void sweepStuckSteps(ctx).catch((err: Error) =>
       workerLogger.error({ err: { message: err.message } }, "watchdog: stuck-step sweep failed"),
     );
@@ -106,7 +107,8 @@ async function main(): Promise<void> {
         "watchdog: overdue-approval sweep failed",
       ),
     );
-  }, WATCHDOG_INTERVAL_MS).unref();
+  }, WATCHDOG_INTERVAL_MS);
+  watchdog.unref();
 
   const app = await buildApp(ctx);
   const host = "0.0.0.0";
@@ -114,6 +116,14 @@ async function main(): Promise<void> {
   await app.listen({ port, host });
   workerLogger.info({ port, host, executor: mode }, "makerchecker server listening");
   await emitRedactionDisabledWarning(pool, workerLogger);
+
+  for (const signal of ["SIGTERM", "SIGINT"] as const) {
+    process.on(signal, () => {
+      void gracefulShutdown({ app, backend, pool, watchdog, logger: workerLogger }).then(() =>
+        process.exit(0),
+      );
+    });
+  }
 }
 
 main().catch((err: Error) => {

--- a/packages/server/src/web-static.test.ts
+++ b/packages/server/src/web-static.test.ts
@@ -36,6 +36,7 @@ describe("isApiPath", () => {
     expect(isApiPath("/api/audit/verify")).toBe(true);
     expect(isApiPath("/api/openapi.json")).toBe(true);
     expect(isApiPath("/healthz")).toBe(true);
+    expect(isApiPath("/readyz")).toBe(true);
     expect(isApiPath("/api/approvals?x=1")).toBe(true);
   });
 

--- a/packages/server/src/web-static.ts
+++ b/packages/server/src/web-static.ts
@@ -17,7 +17,7 @@ import type { FastifyInstance } from "fastify";
  * Every API route lives under /api (see app.ts), so SPA routes like
  * /runs/:id can never collide with it.
  */
-const API_PREFIXES = ["/api", "/healthz"];
+const API_PREFIXES = ["/api", "/healthz", "/readyz"];
 
 /** True when the path belongs to the API surface (exact prefix or a subpath). */
 export function isApiPath(path: string): boolean {


### PR DESCRIPTION
On SIGTERM/SIGINT the server now drains in-flight work instead of orphaning it. Today SIGTERM kills the process immediately, leaving running HTTP requests and queued jobs for the watchdog to reclaim a minute later — so every rolling deploy injected latency spikes and spurious `timed_out`/retry events. Now the pod is pulled from rotation, open requests finish, the queue drains, and it exits cleanly.

## Changes
- **New covered module `boot/lifecycle.ts`** — `isShuttingDown()`/`beginShutdown()` + `gracefulShutdown(deps)`. Sets the flag first (so `/readyz` 503s and the LB deregisters), then tears down in dependency-reverse order: `app.close()` → `backend.stop()` (drains graphile jobs) → `clearInterval(watchdog)` → `pool.end()` **last** (the app and backend query through the pool while draining). Best-effort (a thrown step is logged, the rest run), a hard 25s timeout so a hung drain can't block exit, and idempotent on a double signal.
- **`app.ts`** — a `/readyz` route: 503 while shutting down (checked before any DB work) or when a `SELECT 1` ping throws, else 200. Added to the rate-limit allowlist; open like `/healthz`, which stays a pure liveness stub (green even when the DB is unreachable). This is the readiness-vs-liveness split.
- **`index.ts`** — captured the previously-discarded watchdog `setInterval` handle and wired `SIGTERM`/`SIGINT` → `gracefulShutdown(...)` → exit. No other boot logic changed.
- **`web-static.ts`** — `/readyz` added to `API_PREFIXES` so the SPA fallback can't shadow it in a single-container deploy.

## Tests
`lifecycle.test.ts` covers teardown order, watchdog clear, flag-before-teardown, idempotency, concurrent-call join, best-effort continuation on a thrown step, and the hard-timeout path (fake timers). `app.test.ts` covers `/readyz` 200-ready / 503-shutting-down / 503-DB-down / open-under-auth. **737 server tests pass; coverage holds (`lifecycle.ts` 100%); typecheck, lint, build green.**