### PR TITLE
feat(deploy): add Helm chart for hardened Kubernetes deploy

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -127,6 +127,29 @@ jobs:
           severity: HIGH,CRITICAL
           vuln-type: os,library
 
+  # Helm chart verification (self-verifying, no cluster needed): helm lint catches
+  # a malformed chart; helm template forces a full render so a bad template or a
+  # broken values reference fails here, on the PR's own CI. Each example value set
+  # exercises a different path (external DB, bundled Postgres, single-role), so a
+  # regression in any toggle surfaces without a kind cluster.
+  helm:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: azure/setup-helm@v4
+        with:
+          version: v4.2.1
+      - name: helm lint
+        run: |
+          for f in external-db bundled-eval single-role; do
+            helm lint --strict deploy/helm/makerchecker -f deploy/helm/examples/values-$f.yaml
+          done
+      - name: helm template (render must succeed)
+        run: |
+          for f in external-db bundled-eval single-role; do
+            helm template makerchecker deploy/helm/makerchecker -f deploy/helm/examples/values-$f.yaml > /dev/null
+          done
+
   # SBOM (evidence, non-gating): emit a machine-readable CycloneDX bill of
   # materials a self-hosting regulated buyer can ingest. This generates and
   # uploads evidence — it must never fail the PR, so there is no exit-code here

--- a/README.md
+++ b/README.md
@@ -66,6 +66,8 @@ curl localhost:3000/api/audit/verify -H "$H"
 
 Full local setup, and running with real models, is in [docs/quickstart.md](docs/quickstart.md).
 
+For Kubernetes, a Helm chart — non-root pod, the signing key on a persistent volume, and the two-role hardening applied as a pre-install hook — is in [deploy/helm](deploy/helm/README.md).
+
 The quickstart connects as the Postgres owner, which disables the append-only audit triggers. For tamper-resistance against a compromised app credential, run the server as a non-owner role with [`docker-compose.hardened.yml`](docker-compose.hardened.yml) ([walkthrough](docs/security-model.md#database-hardening-walkthrough)).
 
 ## Packages

--- a/deploy/helm/README.md
+++ b/deploy/helm/README.md
@@ -1,0 +1,131 @@
+# MakerChecker Helm chart
+
+Deploy the MakerChecker server (Fastify on Postgres) to Kubernetes. The chart is
+at [`makerchecker/`](makerchecker). Ready-made value sets are in
+[`examples/`](examples).
+
+```bash
+helm install makerchecker deploy/helm/makerchecker -f deploy/helm/examples/values-external-db.yaml
+```
+
+## What it deploys
+
+- A single Deployment running the server image as non-root uid 1000 under the
+  restricted PodSecurity profile (drop all capabilities, no privilege
+  escalation, read-only root filesystem with a `/tmp` tmpfs, seccomp
+  RuntimeDefault).
+- A PersistentVolumeClaim mounted at `MAKERCHECKER_DATA_DIR` (`/data`) for the
+  instance signing key, with `fsGroup: 1000` so uid 1000 can write it.
+- A ClusterIP Service, an optional Ingress, a PodDisruptionBudget, a
+  ServiceAccount, a ConfigMap (non-secret config), and a Secret (DATABASE_URL
+  and optional provider keys).
+- In hardened mode, a pre-install/pre-upgrade Job that migrates and applies
+  `ops/harden-db.sql` as the database owner before the server rolls out.
+
+## The signing key must persist
+
+On the first key-bearing operation the server writes an Ed25519 private key to
+`/data` and publishes the matching public key to the database exactly once
+(write-once, frozen by a trigger). If that private key is lost on a restart, the
+instance can never again produce a verifiable signed export bundle. So `/data`
+is a PersistentVolumeClaim, never an emptyDir. The chart refuses to render unless
+`persistence.enabled=true` or `persistence.existingClaim` is set. Back the volume
+up and escrow the key as covered in [docs/backup-restore.md](../../docs/backup-restore.md).
+
+## Probes
+
+`livenessProbe` hits `GET /healthz` (no database call, stays green during a
+transient database outage so the pod is not restarted). `readinessProbe` hits
+`GET /readyz` (runs `SELECT 1`, returns 503 while draining or when the database
+is unreachable). Both are unauthenticated and rate-limit-exempt.
+
+## Database: external vs bundled
+
+Set `postgresql.enabled=false` (the default) and point the chart at an external
+managed Postgres. The connection string is read from a Secret you create out of
+band; the chart never templates a connection string into a rendered Secret.
+
+```bash
+kubectl create secret generic makerchecker-db \
+  --from-literal=DATABASE_URL='postgres://mc_app_runtime:<runtime-pw>@db.internal:5432/makerchecker' \
+  --from-literal=DATABASE_URL_OWNER='postgres://makerchecker:<owner-pw>@db.internal:5432/makerchecker' \
+  --from-literal=MC_RUNTIME_PASSWORD='<runtime-pw>'
+
+helm install makerchecker deploy/helm/makerchecker \
+  --set database.existingSecret=makerchecker-db
+```
+
+`postgresql.enabled=true` ships a single-replica Postgres for evaluation only. It
+has no HA and no backups. Do not use it for anything you need to keep. See
+[`examples/values-bundled-eval.yaml`](examples/values-bundled-eval.yaml).
+
+## Single-role vs hardened (two-role)
+
+`hardened.enabled=true` (default) runs the two-role model. A pre-install Job runs
+`node dist/cli.js migrate` then `psql -f ops/harden-db.sql` as the database
+owner; `harden-db.sql` provisions the non-owner `mc_app_runtime` role and revokes
+UPDATE/DELETE/TRUNCATE on `audit_events` and `instance`. The Job is ordered
+before the rollout with a Helm hook; the migrate step is an initContainer that
+must exit 0 before the harden container runs. The server Deployment then connects
+as `mc_app_runtime` with `MAKERCHECKER_SKIP_MIGRATE=1`, because that role lacks
+CREATE on the public schema and cannot run migrations.
+
+The hardened mode needs two distinct connection strings and the runtime password:
+
+| Key | Role | Used by |
+|---|---|---|
+| `DATABASE_URL` | `mc_app_runtime` (non-owner) | server Deployment |
+| `DATABASE_URL_OWNER` | owner | migrate + harden Job |
+| `MC_RUNTIME_PASSWORD` | runtime password | harden Job (sets the role password) |
+
+When you supply `database.existingSecret`, that Secret must carry all three keys.
+`MC_RUNTIME_PASSWORD` is set once: `harden-db.sql` does not reset the role
+password on re-runs, so rotate it out of band with `ALTER ROLE mc_app_runtime
+PASSWORD ...` if needed.
+
+`hardened.enabled=false` is the single-role eval path: the server connects as the
+owner and runs migrations at boot. The owner can disable the append-only audit
+triggers, so use it only for evaluation. See
+[`examples/values-single-role.yaml`](examples/values-single-role.yaml).
+
+## First admin
+
+Nothing is seeded by default. After install, mint the first admin and its API key
+(printed once):
+
+```bash
+kubectl exec deploy/makerchecker -- \
+  node dist/cli.js bootstrap-admin --email admin@your-org.example --name 'Platform Admin'
+```
+
+Verify the audit chain at any time:
+
+```bash
+kubectl exec deploy/makerchecker -- node dist/cli.js audit verify
+```
+
+## Values reference
+
+| Key | Default | Purpose |
+|---|---|---|
+| `image.repository` / `image.tag` / `image.digest` | `ghcr.io/sammysltd/makerchecker-server` / chart appVersion / "" | Server image; digest wins over tag when set |
+| `replicaCount` | `1` | Server replicas |
+| `hardened.enabled` | `true` | Two-role migrate + harden vs single-role eval |
+| `hardened.postgresImage` | `postgres:17-alpine` | Image with psql for the harden step |
+| `database.existingSecret` | `""` | Secret holding DATABASE_URL (and owner URL + runtime password in hardened mode) |
+| `database.runtimeUrlKey` / `database.ownerUrlKey` | `DATABASE_URL` / `DATABASE_URL_OWNER` | Keys read from `existingSecret` |
+| `database.runtimeUrl` / `database.ownerUrl` / `database.runtimePassword` | `""` | Used only when the chart creates the Secret |
+| `secrets.anthropicApiKey` / `secrets.geminiApiKey` | `""` | Optional model provider keys |
+| `config.*` | see [values.yaml](makerchecker/values.yaml) | Non-secret server config (port, dataDir, logLevel, redaction, ...) |
+| `persistence.enabled` / `persistence.existingClaim` / `persistence.size` | `true` / `""` / `1Gi` | Signing-key PVC |
+| `service.type` / `service.port` | `ClusterIP` / `80` | Service |
+| `ingress.enabled` / `ingress.className` / `ingress.hosts` | `false` / `""` / `makerchecker.local` | Ingress |
+| `podDisruptionBudget.enabled` / `minAvailable` | `true` / `1` | PDB |
+| `postgresql.enabled` | `false` | Bundled eval-only Postgres |
+
+## Render the chart locally
+
+```bash
+helm lint deploy/helm/makerchecker -f deploy/helm/examples/values-external-db.yaml
+helm template makerchecker deploy/helm/makerchecker -f deploy/helm/examples/values-external-db.yaml
+```

--- a/deploy/helm/examples/values-bundled-eval.yaml
+++ b/deploy/helm/examples/values-bundled-eval.yaml
@@ -1,0 +1,27 @@
+# EVAL ONLY: bundled single-replica Postgres with two-role hardening. No HA, no
+# backups. Use this to try the chart on a throwaway cluster, never in production.
+hardened:
+  enabled: true
+
+postgresql:
+  enabled: true
+  auth:
+    username: makerchecker
+    password: makerchecker
+    database: makerchecker
+
+database:
+  # Password embedded in the mc_app_runtime DATABASE_URL the chart builds.
+  runtimePassword: change-me-eval
+
+persistence:
+  enabled: true
+  size: 1Gi
+
+ingress:
+  enabled: true
+  hosts:
+    - host: makerchecker.local
+      paths:
+        - path: /
+          pathType: Prefix

--- a/deploy/helm/examples/values-external-db.yaml
+++ b/deploy/helm/examples/values-external-db.yaml
@@ -1,0 +1,31 @@
+# Recommended production shape: external managed Postgres, two-role hardening.
+# The referenced Secret must hold the runtime and owner DATABASE_URLs and
+# MC_RUNTIME_PASSWORD. Create it out of band, for example:
+#
+#   kubectl create secret generic makerchecker-db \
+#     --from-literal=DATABASE_URL='postgres://mc_app_runtime:<pw>@db:5432/makerchecker' \
+#     --from-literal=DATABASE_URL_OWNER='postgres://makerchecker:<owner-pw>@db:5432/makerchecker' \
+#     --from-literal=MC_RUNTIME_PASSWORD='<pw>'
+hardened:
+  enabled: true
+
+database:
+  existingSecret: makerchecker-db
+  runtimeUrlKey: DATABASE_URL
+  ownerUrlKey: DATABASE_URL_OWNER
+
+postgresql:
+  enabled: false
+
+persistence:
+  enabled: true
+  size: 1Gi
+
+ingress:
+  enabled: true
+  className: nginx
+  hosts:
+    - host: makerchecker.example.com
+      paths:
+        - path: /
+          pathType: Prefix

--- a/deploy/helm/examples/values-single-role.yaml
+++ b/deploy/helm/examples/values-single-role.yaml
@@ -1,0 +1,20 @@
+# Single-role eval: the server connects as the database owner and runs migrations
+# at boot. Simplest path, but the owner can disable the append-only audit
+# triggers, so a compromised app credential could rewrite history. Set
+# hardened.enabled=true for tamper-resistance.
+hardened:
+  enabled: false
+
+postgresql:
+  enabled: true
+  auth:
+    username: makerchecker
+    password: makerchecker
+    database: makerchecker
+
+persistence:
+  enabled: true
+  size: 1Gi
+
+ingress:
+  enabled: false

--- a/deploy/helm/makerchecker/.helmignore
+++ b/deploy/helm/makerchecker/.helmignore
@@ -1,0 +1,8 @@
+.DS_Store
+.git/
+.gitignore
+*.tmp
+*.bak
+*.orig
+.idea/
+.vscode/

--- a/deploy/helm/makerchecker/Chart.yaml
+++ b/deploy/helm/makerchecker/Chart.yaml
@@ -1,0 +1,18 @@
+apiVersion: v2
+name: makerchecker
+description: Governance and audit control plane for AI agents (Fastify server on Postgres).
+type: application
+version: 0.1.0
+appVersion: "1.0.0"
+kubeVersion: ">=1.25.0-0"
+home: https://makerchecker.ai
+sources:
+  - https://github.com/sammysltd/makerchecker
+keywords:
+  - audit
+  - governance
+  - postgres
+  - agents
+maintainers:
+  - name: MakerChecker
+    email: hello@makerchecker.ai

--- a/deploy/helm/makerchecker/files/harden-db.sql
+++ b/deploy/helm/makerchecker/files/harden-db.sql
@@ -1,0 +1,257 @@
+-- MakerChecker DB least-privilege hardening (Layer 2 in SECURITY.md / 0001_init.sql).
+--
+-- WHAT THIS CLOSES
+--   The append-only audit_events triggers and the immutable instance-row guard
+--   bind at the TABLE level, but a PostgreSQL table OWNER can DISABLE its own
+--   triggers (ALTER TABLE ... DISABLE TRIGGER) and then UPDATE/DELETE freely.
+--   The single-role docker/quickstart default connects as the owner, so a
+--   compromised application credential could silently rewrite the audit log.
+--   This script provisions a separate runtime role that does NOT own any table
+--   and is REVOKEd UPDATE/DELETE/TRUNCATE on the tamper-evident tables, so it
+--   can APPEND audit rows but can never mutate, delete, truncate, or disable the
+--   guards on them. This is the non-owner runtime role referenced in SECURITY.md.
+--
+-- HOW TO USE (two-role pattern)
+--   1. The OWNER role (the role that created the database and ran the migrations)
+--      applies this script ONCE, after migrations:
+--
+--        psql "$DATABASE_URL_OWNER" -v mc_runtime_password='<strong-password>' \
+--          -f ops/harden-db.sql
+--
+--      Re-running it is safe: every statement below is idempotent.
+--   2. Point the server's DATABASE_URL at mc_app_runtime (NOT the owner). See
+--      docker-compose.hardened.yml for the compose form.
+--
+--   This script does NOT run as part of the normal migrations on purpose:
+--   CREATE ROLE needs elevated privileges that ephemeral CI/test databases (which
+--   run as a single owner/superuser and intentionally DISABLE triggers in
+--   adversarial tests) do not grant. The default single-role flow stays untouched.
+--
+-- IDEMPOTENCY / SAFETY
+--   Run as the table owner (or a superuser). The runtime password is read from
+--   the psql variable :mc_runtime_password and defaults to 'mc_app_runtime' only
+--   so the script never fails when invoked without it; ALWAYS pass a real
+--   password in any deployment you care about, or set it out of band with
+--   ALTER ROLE mc_app_runtime PASSWORD '...'.
+
+\set ON_ERROR_STOP on
+
+-- Default the password variable when the caller did not pass one. psql has no
+-- "default if unset", so test it with a sentinel and override only when missing.
+\if :{?mc_runtime_password}
+\else
+  \set mc_runtime_password 'mc_app_runtime'
+\endif
+
+------------------------------------------------------------------------------
+-- 1. Runtime role. CREATE ROLE is not idempotent, so emit it only when the role
+--    is absent (\gexec runs the row this SELECT returns, none if it exists).
+--    LOGIN so the server can connect; NOSUPERUSER/NOCREATEDB/NOCREATEROLE so a
+--    compromised credential cannot escalate. The password is set in the same
+--    CREATE because the value is interpolated by psql here; psql does NOT
+--    substitute :variables inside a dollar-quoted DO block, so this stays at the
+--    top level.
+--
+--    Re-runs do NOT reset the password: ALTER ROLE ... PASSWORD requires
+--    superuser or ADMIN on the role, which a plain table-owner running this
+--    script may not hold (roles are cluster-global, so the role can pre-exist).
+--    To rotate the password later, run as superuser (or a role with ADMIN on
+--    mc_app_runtime): ALTER ROLE mc_app_runtime PASSWORD '<new>'.
+------------------------------------------------------------------------------
+SELECT format(
+  'CREATE ROLE mc_app_runtime LOGIN NOSUPERUSER NOCREATEDB NOCREATEROLE '
+  || 'NOINHERIT PASSWORD %L',
+  :'mc_runtime_password')
+WHERE NOT EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'mc_app_runtime')
+\gexec
+
+------------------------------------------------------------------------------
+-- 2. Connect + schema usage. The role needs to reach the database and resolve
+--    objects in the public schema, but no DDL rights there (it must not be able
+--    to CREATE shadow tables or functions). current_database() keeps the script
+--    portable across database names.
+------------------------------------------------------------------------------
+DO $$
+BEGIN
+  EXECUTE format('GRANT CONNECT ON DATABASE %I TO mc_app_runtime', current_database());
+END
+$$;
+GRANT USAGE ON SCHEMA public TO mc_app_runtime;
+
+------------------------------------------------------------------------------
+-- 3. Baseline DML on every existing application table. The server reads and
+--    writes mutable run-state (flow_runs, step_runs, approvals, ...) and appends
+--    to the governed/append-only tables. We grant the full SELECT/INSERT/UPDATE/
+--    DELETE set broadly here, then REVOKE the dangerous verbs back from the
+--    tamper-evident tables in step 4. Sequences backing identity/serial columns
+--    need USAGE so INSERTs can draw default values.
+------------------------------------------------------------------------------
+GRANT SELECT, INSERT, UPDATE, DELETE ON ALL TABLES IN SCHEMA public TO mc_app_runtime;
+GRANT USAGE, SELECT ON ALL SEQUENCES IN SCHEMA public TO mc_app_runtime;
+
+-- In the hardened flow the runtime role runs with MAKERCHECKER_SKIP_MIGRATE=1
+-- and never calls migrate(); the owner applies migrations before this script.
+-- This SELECT/INSERT grant is therefore for operational/diagnostic reads of the
+-- migration ledger, not for boot.
+DO $$
+BEGIN
+  IF to_regclass('public.schema_migrations') IS NOT NULL THEN
+    GRANT SELECT, INSERT ON schema_migrations TO mc_app_runtime;
+  END IF;
+END
+$$;
+
+------------------------------------------------------------------------------
+-- 4. graphile_worker queue access. The owner installs the graphile_worker schema
+--    during `migrate` (migrateGraphileWorkerSchema); the runtime role only USES
+--    it — graphile-worker's startup migrate is a no-op once the schema is current,
+--    so the runtime role never needs CREATE. Grant USAGE + table/sequence/function
+--    privileges on the existing objects, plus matching DEFAULT PRIVILEGES keyed to
+--    the schema owner so future graphile-worker upgrades stay covered. graphile-
+--    worker ENABLEs row-level security on its job tables but ships NO policies
+--    (RLS-on + no-policy = deny-all for non-owners, while the owner bypasses it),
+--    so a permissive ALL policy per RLS table is required for the non-owner role
+--    to enqueue/consume. If the schema is absent the operator skipped `migrate`;
+--    warn and continue (the rest of this script is still valid for the app tables).
+------------------------------------------------------------------------------
+DO $$
+DECLARE
+  gw_owner text;
+  gw_table text;
+BEGIN
+  IF to_regnamespace('graphile_worker') IS NULL THEN
+    RAISE WARNING 'graphile_worker schema not found; run `node dist/cli.js migrate` as the owner first, then re-run this script';
+  ELSE
+    GRANT USAGE ON SCHEMA graphile_worker TO mc_app_runtime;
+    GRANT SELECT, INSERT, UPDATE, DELETE ON ALL TABLES IN SCHEMA graphile_worker TO mc_app_runtime;
+    GRANT USAGE, SELECT ON ALL SEQUENCES IN SCHEMA graphile_worker TO mc_app_runtime;
+    GRANT EXECUTE ON ALL FUNCTIONS IN SCHEMA graphile_worker TO mc_app_runtime;
+
+    SELECT pg_get_userbyid(nspowner) INTO gw_owner
+    FROM pg_namespace WHERE nspname = 'graphile_worker';
+    EXECUTE format(
+      'ALTER DEFAULT PRIVILEGES FOR ROLE %I IN SCHEMA graphile_worker '
+      || 'GRANT SELECT, INSERT, UPDATE, DELETE ON TABLES TO mc_app_runtime',
+      gw_owner);
+    EXECUTE format(
+      'ALTER DEFAULT PRIVILEGES FOR ROLE %I IN SCHEMA graphile_worker '
+      || 'GRANT USAGE, SELECT ON SEQUENCES TO mc_app_runtime',
+      gw_owner);
+    EXECUTE format(
+      'ALTER DEFAULT PRIVILEGES FOR ROLE %I IN SCHEMA graphile_worker '
+      || 'GRANT EXECUTE ON FUNCTIONS TO mc_app_runtime',
+      gw_owner);
+
+    FOR gw_table IN
+      SELECT c.relname
+      FROM pg_class c
+      JOIN pg_namespace n ON n.oid = c.relnamespace
+      WHERE n.nspname = 'graphile_worker' AND c.relkind = 'r' AND c.relrowsecurity
+    LOOP
+      EXECUTE format('DROP POLICY IF EXISTS mc_app_runtime_all ON graphile_worker.%I', gw_table);
+      EXECUTE format(
+        'CREATE POLICY mc_app_runtime_all ON graphile_worker.%I '
+        || 'FOR ALL TO mc_app_runtime USING (true) WITH CHECK (true)',
+        gw_table);
+    END LOOP;
+  END IF;
+END
+$$;
+
+------------------------------------------------------------------------------
+-- 5. Lock down the tamper-evident tables. audit_events is append-only: the
+--    runtime role keeps SELECT + INSERT (append a new audit row) but loses
+--    UPDATE, DELETE, and TRUNCATE. instance is write-once and is seeded by the
+--    owner migration (0001_init.sql: INSERT INTO instance DEFAULT VALUES); the
+--    runtime role only ever does UPDATE(public_key_pem) (granted below) and never
+--    INSERTs, so it loses INSERT, UPDATE, DELETE, and TRUNCATE here. Without
+--    UPDATE/DELETE the role cannot rewrite history even if a logic sink is found;
+--    not owning the tables, it also cannot ALTER TABLE ... DISABLE TRIGGER to
+--    defeat the append-only guards. TRUNCATE is owner-only by default in Postgres,
+--    but REVOKE it explicitly so intent is documented and a future broad GRANT
+--    cannot silently re-enable it.
+------------------------------------------------------------------------------
+REVOKE UPDATE, DELETE, TRUNCATE ON audit_events FROM mc_app_runtime;
+REVOKE INSERT, UPDATE, DELETE, TRUNCATE ON instance FROM mc_app_runtime;
+
+------------------------------------------------------------------------------
+-- 6. One-time first-boot key publication. ensureInstanceKeys publishes the
+--    instance Ed25519 public key exactly once (instance.public_key_pem: NULL ->
+--    value) on the first key-bearing operation. The instance_immutable trigger
+--    already makes that the ONLY permitted UPDATE (write-once, no rotation), so a
+--    column-scoped UPDATE(public_key_pem) is safe to grant: the role can fill the
+--    key once and nothing more. After publication, steady state needs only
+--    SELECT. Pre-seeding instance.public_key_pem as the owner and skipping this
+--    grant is an equally valid, tighter option (see SECURITY.md).
+------------------------------------------------------------------------------
+GRANT UPDATE (public_key_pem) ON instance TO mc_app_runtime;
+
+------------------------------------------------------------------------------
+-- 7. Future tables fail closed. ALTER DEFAULT PRIVILEGES is keyed to the role
+--    that CREATES the future object (FOR ROLE ...), not to whoever runs this
+--    script. Migrations are applied by the table owner, which may differ from the
+--    (possibly superuser) role bootstrapping this hardening. So set the defaults
+--    FOR each role that owns an existing application table -- i.e. the migration
+--    owner(s). The default grant is SELECT, INSERT only: a future tamper-evident /
+--    append-only table is then locked down by default and needs no extra REVOKE.
+--    A future MUTABLE table needs an explicit GRANT UPDATE, DELETE line added here
+--    after this loop. Existing tables already received full DML via the broad
+--    grant in step 3; this default only governs tables added by later migrations.
+------------------------------------------------------------------------------
+DO $$
+DECLARE
+  owner_role text;
+BEGIN
+  FOR owner_role IN
+    SELECT DISTINCT pg_get_userbyid(c.relowner)
+    FROM pg_class c
+    JOIN pg_namespace n ON n.oid = c.relnamespace
+    WHERE n.nspname = 'public' AND c.relkind = 'r'
+  LOOP
+    EXECUTE format(
+      'ALTER DEFAULT PRIVILEGES FOR ROLE %I IN SCHEMA public '
+      || 'GRANT SELECT, INSERT ON TABLES TO mc_app_runtime',
+      owner_role);
+    EXECUTE format(
+      'ALTER DEFAULT PRIVILEGES FOR ROLE %I IN SCHEMA public '
+      || 'GRANT USAGE, SELECT ON SEQUENCES TO mc_app_runtime',
+      owner_role);
+  END LOOP;
+END
+$$;
+
+------------------------------------------------------------------------------
+-- 8. Final precondition. The CREATE ROLE above pins NOSUPERUSER/NOINHERIT, but
+--    those flags only apply at creation and the role may pre-exist (roles are
+--    cluster-global), so a stale or hand-edited mc_app_runtime could already be a
+--    superuser or a member of a table-owning role. Either would let it SET ROLE to
+--    an owner and ALTER TABLE ... DISABLE TRIGGER, voiding the whole guarantee.
+--    Fail loudly here rather than hand back a role that silently does not enforce.
+------------------------------------------------------------------------------
+DO $$
+DECLARE
+  bad_owner text;
+BEGIN
+  IF EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'mc_app_runtime' AND rolsuper) THEN
+    RAISE EXCEPTION 'mc_app_runtime is a superuser; it could bypass the audit triggers. Recreate it NOSUPERUSER.';
+  END IF;
+
+  SELECT DISTINCT pg_get_userbyid(c.relowner) INTO bad_owner
+  FROM pg_class c
+  JOIN pg_namespace n ON n.oid = c.relnamespace
+  WHERE n.nspname = 'public' AND c.relkind = 'r'
+    AND pg_has_role('mc_app_runtime', c.relowner, 'MEMBER')
+    AND pg_get_userbyid(c.relowner) <> 'mc_app_runtime'
+  LIMIT 1;
+  IF bad_owner IS NOT NULL THEN
+    RAISE EXCEPTION 'mc_app_runtime is a member of table-owning role %; it could SET ROLE and disable the audit triggers. Revoke that membership.', bad_owner;
+  END IF;
+END
+$$;
+
+------------------------------------------------------------------------------
+-- Done. Verify with:
+--   \dp audit_events instance         -- runtime role should show r/a only on these
+--   SELECT has_table_privilege('mc_app_runtime', 'audit_events', 'UPDATE'); -- f
+--   SELECT has_table_privilege('mc_app_runtime', 'audit_events', 'INSERT'); -- t
+------------------------------------------------------------------------------

--- a/deploy/helm/makerchecker/templates/NOTES.txt
+++ b/deploy/helm/makerchecker/templates/NOTES.txt
@@ -1,0 +1,52 @@
+MakerChecker is installed as release {{ .Release.Name }} in namespace {{ .Release.Namespace }}.
+
+Server image: {{ include "makerchecker.image" . }}
+
+Reach the API and web UI:
+
+  kubectl --namespace {{ .Release.Namespace }} port-forward svc/{{ include "makerchecker.fullname" . }} 3000:{{ .Values.service.port }}
+  # then open http://localhost:3000/healthz
+
+{{- if .Values.ingress.enabled }}
+
+Ingress is enabled at:
+{{- range .Values.ingress.hosts }}
+  http://{{ .host }}
+{{- end }}
+{{- end }}
+
+Deployment mode:
+{{- if .Values.hardened.enabled }}
+  Hardened two-role. A pre-install/pre-upgrade Job ran migrations then
+  ops/harden-db.sql as the database owner; the server connects as the non-owner
+  mc_app_runtime role with MAKERCHECKER_SKIP_MIGRATE=1 and cannot mutate or
+  truncate audit_events / instance.
+{{- else }}
+  Single-role (eval). The server connects as the database owner and runs
+  migrations at boot. The owner can disable the append-only audit triggers, so
+  set hardened.enabled=true for tamper-resistance against a compromised app
+  credential.
+{{- end }}
+
+{{- if .Values.postgresql.enabled }}
+
+WARNING: postgresql.enabled=true ships a single-replica eval Postgres with no HA
+and no backups. For any real deployment set postgresql.enabled=false and supply
+an external managed Postgres through database.existingSecret.
+{{- end }}
+
+{{- if .Values.config.seedDemo }}
+
+WARNING: config.seedDemo=true provisions a demo admin and prints an admin API
+key in the logs. Never leave this on for a real deployment.
+{{- end }}
+
+Mint the first admin (nothing is seeded by default):
+
+  kubectl --namespace {{ .Release.Namespace }} exec deploy/{{ include "makerchecker.fullname" . }} -- \
+    node dist/cli.js bootstrap-admin --email admin@your-org.example --name 'Platform Admin'
+
+Verify the audit chain:
+
+  kubectl --namespace {{ .Release.Namespace }} exec deploy/{{ include "makerchecker.fullname" . }} -- \
+    node dist/cli.js audit verify

--- a/deploy/helm/makerchecker/templates/_helpers.tpl
+++ b/deploy/helm/makerchecker/templates/_helpers.tpl
@@ -1,0 +1,119 @@
+{{- define "makerchecker.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{- define "makerchecker.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "makerchecker.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{- define "makerchecker.labels" -}}
+helm.sh/chart: {{ include "makerchecker.chart" . }}
+{{ include "makerchecker.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end -}}
+
+{{- define "makerchecker.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "makerchecker.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end -}}
+
+{{- define "makerchecker.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create -}}
+{{- default (include "makerchecker.fullname" .) .Values.serviceAccount.name -}}
+{{- else -}}
+{{- default "default" .Values.serviceAccount.name -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "makerchecker.image" -}}
+{{- $tag := default .Chart.AppVersion .Values.image.tag -}}
+{{- if .Values.image.digest -}}
+{{- printf "%s@%s" .Values.image.repository .Values.image.digest -}}
+{{- else -}}
+{{- printf "%s:%s" .Values.image.repository $tag -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Name of the Secret holding DATABASE_URL (and optional API keys). Either the
+operator-supplied existingSecret, or one created by this chart.
+*/}}
+{{- define "makerchecker.secretName" -}}
+{{- if .Values.database.existingSecret -}}
+{{- .Values.database.existingSecret -}}
+{{- else -}}
+{{- printf "%s-env" (include "makerchecker.fullname" .) -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "makerchecker.configMapName" -}}
+{{- printf "%s-config" (include "makerchecker.fullname" .) -}}
+{{- end -}}
+
+{{- define "makerchecker.runtimeUrlKey" -}}
+{{- if .Values.database.existingSecret -}}
+{{- .Values.database.runtimeUrlKey -}}
+{{- else -}}
+DATABASE_URL
+{{- end -}}
+{{- end -}}
+
+{{- define "makerchecker.ownerUrlKey" -}}
+{{- if .Values.database.existingSecret -}}
+{{- .Values.database.ownerUrlKey -}}
+{{- else -}}
+DATABASE_URL_OWNER
+{{- end -}}
+{{- end -}}
+
+{{/*
+Bundled-Postgres connection host:port. Only meaningful when postgresql.enabled.
+*/}}
+{{- define "makerchecker.bundledPostgresHost" -}}
+{{- printf "%s-postgresql:%v" (include "makerchecker.fullname" .) .Values.postgresql.service.port -}}
+{{- end -}}
+
+{{/*
+Resolve the owner DATABASE_URL when the chart creates the Secret. With bundled
+Postgres it is derived; otherwise it falls back to database.ownerUrl.
+*/}}
+{{- define "makerchecker.resolvedOwnerUrl" -}}
+{{- if .Values.postgresql.enabled -}}
+{{- $a := .Values.postgresql.auth -}}
+{{- printf "postgres://%s:%s@%s/%s" $a.username $a.password (include "makerchecker.bundledPostgresHost" .) $a.database -}}
+{{- else -}}
+{{- .Values.database.ownerUrl -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Resolve the runtime DATABASE_URL when the chart creates the Secret. In hardened
+mode with bundled Postgres it embeds the mc_app_runtime credential; otherwise it
+falls back to database.runtimeUrl.
+*/}}
+{{- define "makerchecker.resolvedRuntimeUrl" -}}
+{{- if and .Values.hardened.enabled .Values.postgresql.enabled -}}
+{{- $a := .Values.postgresql.auth -}}
+{{- printf "postgres://mc_app_runtime:%s@%s/%s" .Values.database.runtimePassword (include "makerchecker.bundledPostgresHost" .) $a.database -}}
+{{- else if .Values.postgresql.enabled -}}
+{{- include "makerchecker.resolvedOwnerUrl" . -}}
+{{- else -}}
+{{- .Values.database.runtimeUrl -}}
+{{- end -}}
+{{- end -}}

--- a/deploy/helm/makerchecker/templates/configmap.yaml
+++ b/deploy/helm/makerchecker/templates/configmap.yaml
@@ -1,0 +1,41 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "makerchecker.configMapName" . }}
+  labels:
+    {{- include "makerchecker.labels" . | nindent 4 }}
+data:
+  PORT: {{ .Values.config.port | quote }}
+  MAKERCHECKER_DATA_DIR: {{ .Values.config.dataDir | quote }}
+  MAKERCHECKER_LOG_LEVEL: {{ .Values.config.logLevel | quote }}
+  HOME: /tmp
+  {{- if .Values.config.redaction }}
+  MAKERCHECKER_REDACTION: {{ .Values.config.redaction | quote }}
+  {{- end }}
+  {{- if .Values.config.requireIdentityGates }}
+  MAKERCHECKER_REQUIRE_IDENTITY_GATES: "1"
+  {{- end }}
+  {{- if .Values.config.seedDemo }}
+  MAKERCHECKER_SEED_DEMO: "1"
+  {{- end }}
+  {{- if .Values.config.metrics }}
+  MAKERCHECKER_METRICS: "1"
+  {{- end }}
+  {{- if .Values.config.allowedOrigins }}
+  ALLOWED_ORIGINS: {{ .Values.config.allowedOrigins | quote }}
+  {{- end }}
+  {{- if .Values.config.executor }}
+  MAKERCHECKER_EXECUTOR: {{ .Values.config.executor | quote }}
+  {{- end }}
+  {{- if .Values.config.model }}
+  MAKERCHECKER_MODEL: {{ .Values.config.model | quote }}
+  {{- end }}
+  {{- if .Values.config.stdioAllowedCommands }}
+  MAKERCHECKER_STDIO_ALLOWED_COMMANDS: {{ .Values.config.stdioAllowedCommands | quote }}
+  {{- end }}
+  {{- if .Values.config.demoDataDir }}
+  DEMO_DATA_DIR: {{ .Values.config.demoDataDir | quote }}
+  {{- end }}
+  {{- range $k, $v := .Values.config.extraEnv }}
+  {{ $k }}: {{ $v | quote }}
+  {{- end }}

--- a/deploy/helm/makerchecker/templates/deployment.yaml
+++ b/deploy/helm/makerchecker/templates/deployment.yaml
@@ -1,0 +1,132 @@
+{{- if and (not .Values.persistence.enabled) (not .Values.persistence.existingClaim) }}
+{{- fail "persistence.enabled is false and no persistence.existingClaim is set. The instance signing key at config.dataDir must persist across restarts (its public key is published write-once), so a PVC is required. Set persistence.enabled=true or persistence.existingClaim." }}
+{{- end }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "makerchecker.fullname" . }}
+  labels:
+    {{- include "makerchecker.labels" . | nindent 4 }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      {{- include "makerchecker.selectorLabels" . | nindent 6 }}
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 0
+      maxSurge: 1
+  template:
+    metadata:
+      labels:
+        {{- include "makerchecker.selectorLabels" . | nindent 8 }}
+        {{- with .Values.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      annotations:
+        checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
+        {{- with .Values.podAnnotations }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+    spec:
+      serviceAccountName: {{ include "makerchecker.serviceAccountName" . }}
+      automountServiceAccountToken: false
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1000
+        runAsGroup: 1000
+        fsGroup: 1000
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+        - name: server
+          image: {{ include "makerchecker.image" . }}
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 1000
+            runAsGroup: 1000
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop:
+                - ALL
+            seccompProfile:
+              type: RuntimeDefault
+          ports:
+            - name: http
+              containerPort: {{ .Values.config.port }}
+          envFrom:
+            - configMapRef:
+                name: {{ include "makerchecker.configMapName" . }}
+          env:
+            - name: DATABASE_URL
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "makerchecker.secretName" . }}
+                  key: {{ include "makerchecker.runtimeUrlKey" . }}
+            {{- if .Values.hardened.enabled }}
+            - name: MAKERCHECKER_SKIP_MIGRATE
+              value: "1"
+            {{- end }}
+            {{- if .Values.secrets.anthropicApiKey }}
+            - name: ANTHROPIC_API_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "makerchecker.secretName" . }}
+                  key: ANTHROPIC_API_KEY
+            {{- end }}
+            {{- if .Values.secrets.geminiApiKey }}
+            - name: GEMINI_API_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "makerchecker.secretName" . }}
+                  key: GEMINI_API_KEY
+            {{- end }}
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: http
+            initialDelaySeconds: {{ .Values.probes.liveness.initialDelaySeconds }}
+            periodSeconds: {{ .Values.probes.liveness.periodSeconds }}
+            timeoutSeconds: {{ .Values.probes.liveness.timeoutSeconds }}
+            failureThreshold: {{ .Values.probes.liveness.failureThreshold }}
+          readinessProbe:
+            httpGet:
+              path: /readyz
+              port: http
+            initialDelaySeconds: {{ .Values.probes.readiness.initialDelaySeconds }}
+            periodSeconds: {{ .Values.probes.readiness.periodSeconds }}
+            timeoutSeconds: {{ .Values.probes.readiness.timeoutSeconds }}
+            failureThreshold: {{ .Values.probes.readiness.failureThreshold }}
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+          volumeMounts:
+            - name: data
+              mountPath: {{ .Values.config.dataDir }}
+            - name: tmp
+              mountPath: /tmp
+      volumes:
+        - name: data
+          persistentVolumeClaim:
+            claimName: {{ .Values.persistence.existingClaim | default (printf "%s-data" (include "makerchecker.fullname" .)) }}
+        - name: tmp
+          emptyDir:
+            medium: Memory
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/deploy/helm/makerchecker/templates/ingress.yaml
+++ b/deploy/helm/makerchecker/templates/ingress.yaml
@@ -1,0 +1,37 @@
+{{- if .Values.ingress.enabled }}
+{{- $fullName := include "makerchecker.fullname" . }}
+{{- $svcPort := .Values.service.port }}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ $fullName }}
+  labels:
+    {{- include "makerchecker.labels" . | nindent 4 }}
+  {{- with .Values.ingress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- if .Values.ingress.className }}
+  ingressClassName: {{ .Values.ingress.className }}
+  {{- end }}
+  {{- with .Values.ingress.tls }}
+  tls:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  rules:
+    {{- range .Values.ingress.hosts }}
+    - host: {{ .host | quote }}
+      http:
+        paths:
+          {{- range .paths }}
+          - path: {{ .path }}
+            pathType: {{ .pathType }}
+            backend:
+              service:
+                name: {{ $fullName }}
+                port:
+                  number: {{ $svcPort }}
+          {{- end }}
+    {{- end }}
+{{- end }}

--- a/deploy/helm/makerchecker/templates/migrate-job.yaml
+++ b/deploy/helm/makerchecker/templates/migrate-job.yaml
@@ -1,0 +1,134 @@
+{{- if .Values.hardened.enabled }}
+{{- $secretName := include "makerchecker.secretName" . }}
+{{- $ownerKey := include "makerchecker.ownerUrlKey" . }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "makerchecker.fullname" . }}-harden-sql
+  labels:
+    {{- include "makerchecker.labels" . | nindent 4 }}
+  annotations:
+    helm.sh/hook: pre-install,pre-upgrade
+    helm.sh/hook-weight: "-5"
+    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
+data:
+  harden-db.sql: |-
+{{ .Files.Get "files/harden-db.sql" | indent 4 }}
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ include "makerchecker.fullname" . }}-migrate-harden
+  labels:
+    {{- include "makerchecker.labels" . | nindent 4 }}
+  annotations:
+    helm.sh/hook: pre-install,pre-upgrade
+    helm.sh/hook-weight: "0"
+    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
+spec:
+  backoffLimit: 1
+  template:
+    metadata:
+      labels:
+        {{- include "makerchecker.selectorLabels" . | nindent 8 }}
+    spec:
+      restartPolicy: Never
+      serviceAccountName: {{ include "makerchecker.serviceAccountName" . }}
+      automountServiceAccountToken: false
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1000
+        runAsGroup: 1000
+        fsGroup: 1000
+        seccompProfile:
+          type: RuntimeDefault
+      # Ordered: migrate (owner) runs as an initContainer and must exit 0 before
+      # the harden container runs. Both carry the OWNER credential; the long-
+      # running Deployment uses the non-owner runtime credential instead.
+      initContainers:
+        - name: migrate
+          image: {{ include "makerchecker.image" . }}
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          command: ["node", "dist/cli.js", "migrate"]
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop:
+                - ALL
+            seccompProfile:
+              type: RuntimeDefault
+          env:
+            - name: HOME
+              value: /tmp
+            - name: DATABASE_URL
+              valueFrom:
+                secretKeyRef:
+                  name: {{ $secretName }}
+                  key: {{ $ownerKey }}
+          volumeMounts:
+            - name: tmp
+              mountPath: /tmp
+      containers:
+        - name: harden
+          image: {{ .Values.hardened.postgresImage | quote }}
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop:
+                - ALL
+            seccompProfile:
+              type: RuntimeDefault
+          command: ["/bin/sh", "-c"]
+          args:
+            - |
+              set -e
+              psql "$DATABASE_URL_OWNER" \
+                -v ON_ERROR_STOP=1 \
+                -v mc_runtime_password="$MC_RUNTIME_PASSWORD" \
+                -f /ops/harden-db.sql
+          env:
+            - name: HOME
+              value: /tmp
+            - name: DATABASE_URL_OWNER
+              valueFrom:
+                secretKeyRef:
+                  name: {{ $secretName }}
+                  key: {{ $ownerKey }}
+            - name: MC_RUNTIME_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ $secretName }}
+                  key: MC_RUNTIME_PASSWORD
+          volumeMounts:
+            - name: ops
+              mountPath: /ops
+              readOnly: true
+            - name: tmp
+              mountPath: /tmp
+      volumes:
+        - name: ops
+          configMap:
+            name: {{ include "makerchecker.fullname" . }}-harden-sql
+        - name: tmp
+          emptyDir:
+            medium: Memory
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+{{- end }}

--- a/deploy/helm/makerchecker/templates/persistentvolumeclaim.yaml
+++ b/deploy/helm/makerchecker/templates/persistentvolumeclaim.yaml
@@ -1,0 +1,21 @@
+{{- if and .Values.persistence.enabled (not .Values.persistence.existingClaim) }}
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ include "makerchecker.fullname" . }}-data
+  labels:
+    {{- include "makerchecker.labels" . | nindent 4 }}
+  {{- with .Values.persistence.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  accessModes:
+    {{- toYaml .Values.persistence.accessModes | nindent 4 }}
+  {{- if .Values.persistence.storageClassName }}
+  storageClassName: {{ .Values.persistence.storageClassName | quote }}
+  {{- end }}
+  resources:
+    requests:
+      storage: {{ .Values.persistence.size | quote }}
+{{- end }}

--- a/deploy/helm/makerchecker/templates/poddisruptionbudget.yaml
+++ b/deploy/helm/makerchecker/templates/poddisruptionbudget.yaml
@@ -1,0 +1,18 @@
+{{- if .Values.podDisruptionBudget.enabled }}
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ include "makerchecker.fullname" . }}
+  labels:
+    {{- include "makerchecker.labels" . | nindent 4 }}
+spec:
+  {{- if .Values.podDisruptionBudget.minAvailable }}
+  minAvailable: {{ .Values.podDisruptionBudget.minAvailable }}
+  {{- end }}
+  {{- if .Values.podDisruptionBudget.maxUnavailable }}
+  maxUnavailable: {{ .Values.podDisruptionBudget.maxUnavailable }}
+  {{- end }}
+  selector:
+    matchLabels:
+      {{- include "makerchecker.selectorLabels" . | nindent 6 }}
+{{- end }}

--- a/deploy/helm/makerchecker/templates/postgresql.yaml
+++ b/deploy/helm/makerchecker/templates/postgresql.yaml
@@ -1,0 +1,128 @@
+{{- if .Values.postgresql.enabled }}
+{{- /*
+EVAL ONLY. Single replica, no HA, no backups. Production sets
+postgresql.enabled=false and points database.existingSecret at an external
+managed Postgres.
+*/}}
+{{- $name := printf "%s-postgresql" (include "makerchecker.fullname" .) }}
+{{- $auth := .Values.postgresql.auth }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ $name }}
+  labels:
+    {{- include "makerchecker.labels" . | nindent 4 }}
+type: Opaque
+stringData:
+  POSTGRES_USER: {{ $auth.username | quote }}
+  POSTGRES_PASSWORD: {{ $auth.password | quote }}
+  POSTGRES_DB: {{ $auth.database | quote }}
+---
+{{- if .Values.postgresql.persistence.enabled }}
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ $name }}-data
+  labels:
+    {{- include "makerchecker.labels" . | nindent 4 }}
+spec:
+  accessModes:
+    - ReadWriteOnce
+  {{- if .Values.postgresql.persistence.storageClassName }}
+  storageClassName: {{ .Values.postgresql.persistence.storageClassName | quote }}
+  {{- end }}
+  resources:
+    requests:
+      storage: {{ .Values.postgresql.persistence.size | quote }}
+---
+{{- end }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ $name }}
+  labels:
+    {{- include "makerchecker.labels" . | nindent 4 }}
+spec:
+  type: ClusterIP
+  selector:
+    {{- include "makerchecker.selectorLabels" . | nindent 4 }}
+    app.kubernetes.io/component: postgresql
+  ports:
+    - name: postgres
+      port: {{ .Values.postgresql.service.port }}
+      targetPort: postgres
+      protocol: TCP
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ $name }}
+  labels:
+    {{- include "makerchecker.labels" . | nindent 4 }}
+    app.kubernetes.io/component: postgresql
+spec:
+  replicas: 1
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      {{- include "makerchecker.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: postgresql
+  template:
+    metadata:
+      labels:
+        {{- include "makerchecker.selectorLabels" . | nindent 8 }}
+        app.kubernetes.io/component: postgresql
+    spec:
+      automountServiceAccountToken: false
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 70
+        runAsGroup: 70
+        fsGroup: 70
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+        - name: postgres
+          image: {{ .Values.postgresql.image | quote }}
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+            seccompProfile:
+              type: RuntimeDefault
+          envFrom:
+            - secretRef:
+                name: {{ $name }}
+          env:
+            - name: PGDATA
+              value: /var/lib/postgresql/data/pgdata
+          ports:
+            - name: postgres
+              containerPort: 5432
+          readinessProbe:
+            exec:
+              command: ["pg_isready", "-U", {{ $auth.username | quote }}]
+            initialDelaySeconds: 5
+            periodSeconds: 5
+          livenessProbe:
+            exec:
+              command: ["pg_isready", "-U", {{ $auth.username | quote }}]
+            initialDelaySeconds: 15
+            periodSeconds: 10
+          resources:
+            {{- toYaml .Values.postgresql.resources | nindent 12 }}
+          volumeMounts:
+            - name: data
+              mountPath: /var/lib/postgresql/data
+      volumes:
+        - name: data
+          {{- if .Values.postgresql.persistence.enabled }}
+          persistentVolumeClaim:
+            claimName: {{ $name }}-data
+          {{- else }}
+          emptyDir: {}
+          {{- end }}
+{{- end }}

--- a/deploy/helm/makerchecker/templates/secret.yaml
+++ b/deploy/helm/makerchecker/templates/secret.yaml
@@ -1,0 +1,29 @@
+{{- if not .Values.database.existingSecret }}
+{{- $runtimeUrl := include "makerchecker.resolvedRuntimeUrl" . }}
+{{- if not $runtimeUrl }}
+{{- fail "database.existingSecret is empty and no DATABASE_URL is resolvable. Set database.existingSecret, or database.runtimeUrl (single-role), or enable postgresql." }}
+{{- end }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "makerchecker.secretName" . }}
+  labels:
+    {{- include "makerchecker.labels" . | nindent 4 }}
+type: Opaque
+stringData:
+  DATABASE_URL: {{ $runtimeUrl | quote }}
+  {{- if .Values.hardened.enabled }}
+  {{- $ownerUrl := include "makerchecker.resolvedOwnerUrl" . }}
+  {{- if not $ownerUrl }}
+  {{- fail "hardened.enabled is true but no owner DATABASE_URL is resolvable. Set database.ownerUrl or enable postgresql." }}
+  {{- end }}
+  DATABASE_URL_OWNER: {{ $ownerUrl | quote }}
+  MC_RUNTIME_PASSWORD: {{ required "database.runtimePassword is required in hardened mode when the chart creates the Secret" .Values.database.runtimePassword | quote }}
+  {{- end }}
+  {{- if .Values.secrets.anthropicApiKey }}
+  ANTHROPIC_API_KEY: {{ .Values.secrets.anthropicApiKey | quote }}
+  {{- end }}
+  {{- if .Values.secrets.geminiApiKey }}
+  GEMINI_API_KEY: {{ .Values.secrets.geminiApiKey | quote }}
+  {{- end }}
+{{- end }}

--- a/deploy/helm/makerchecker/templates/service.yaml
+++ b/deploy/helm/makerchecker/templates/service.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "makerchecker.fullname" . }}
+  labels:
+    {{- include "makerchecker.labels" . | nindent 4 }}
+  {{- with .Values.service.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  type: {{ .Values.service.type }}
+  selector:
+    {{- include "makerchecker.selectorLabels" . | nindent 4 }}
+  ports:
+    - name: http
+      port: {{ .Values.service.port }}
+      targetPort: http
+      protocol: TCP

--- a/deploy/helm/makerchecker/templates/serviceaccount.yaml
+++ b/deploy/helm/makerchecker/templates/serviceaccount.yaml
@@ -1,0 +1,13 @@
+{{- if .Values.serviceAccount.create }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "makerchecker.serviceAccountName" . }}
+  labels:
+    {{- include "makerchecker.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+automountServiceAccountToken: false
+{{- end }}

--- a/deploy/helm/makerchecker/values.yaml
+++ b/deploy/helm/makerchecker/values.yaml
@@ -1,0 +1,150 @@
+replicaCount: 1
+
+image:
+  repository: ghcr.io/sammysltd/makerchecker-server
+  # Defaults to .Chart.appVersion when empty.
+  tag: ""
+  # A sha256 digest pins the image; when set it overrides tag.
+  digest: ""
+  pullPolicy: IfNotPresent
+
+imagePullSecrets: []
+nameOverride: ""
+fullnameOverride: ""
+
+serviceAccount:
+  create: true
+  name: ""
+  annotations: {}
+
+# Two-role DB hardening. When enabled, a pre-install/pre-upgrade Job runs
+# migrations then ops/harden-db.sql as the owner, and the Deployment connects as
+# the non-owner mc_app_runtime role with MAKERCHECKER_SKIP_MIGRATE=1. When
+# disabled (single-role eval), the server connects as the owner and runs
+# migrations at boot.
+hardened:
+  enabled: true
+  # Image carrying psql for the harden step. The server image ships no psql.
+  postgresImage: postgres:17-alpine
+
+# DATABASE_URL source. With existingSecret set, the chart never templates a
+# connection string; it reads it from the named Secret.
+database:
+  # Reference an operator-managed Secret instead of letting the chart create one.
+  existingSecret: ""
+  # Key in existingSecret holding the runtime (server) DATABASE_URL.
+  runtimeUrlKey: DATABASE_URL
+  # Key in existingSecret holding the owner DATABASE_URL (hardened mode only).
+  ownerUrlKey: DATABASE_URL_OWNER
+  # Used only when existingSecret is empty and the chart creates the Secret.
+  # The runtime URL is required in single-role mode; in hardened mode the chart
+  # builds the runtime URL from the owner host and runtimePassword.
+  runtimeUrl: ""
+  ownerUrl: ""
+  # Password for the mc_app_runtime role (hardened mode). Set once; harden-db.sql
+  # does not reset it on re-runs.
+  runtimePassword: ""
+
+# Provider API keys (optional). Left out of the Secret when blank.
+secrets:
+  anthropicApiKey: ""
+  geminiApiKey: ""
+
+# Non-secret server configuration (rendered into a ConfigMap).
+config:
+  port: 3000
+  dataDir: /data
+  logLevel: info
+  # Redaction hook: example, standard, or "" (no redaction).
+  redaction: standard
+  # Demo seeding provisions an admin and prints its key; keep off in a cluster.
+  seedDemo: false
+  requireIdentityGates: false
+  metrics: false
+  allowedOrigins: ""
+  executor: ""
+  model: ""
+  stdioAllowedCommands: ""
+  demoDataDir: ""
+  # Extra plain env entries (name -> value).
+  extraEnv: {}
+
+# PersistentVolumeClaim for the instance Ed25519 signing key at dataDir. It MUST
+# survive pod restarts: the public key is published to the database write-once,
+# so a lost private key permanently breaks signed-bundle verification. Never
+# back this with emptyDir.
+persistence:
+  enabled: true
+  existingClaim: ""
+  storageClassName: ""
+  accessModes:
+    - ReadWriteOnce
+  size: 1Gi
+  annotations: {}
+
+service:
+  type: ClusterIP
+  port: 80
+  targetPort: 3000
+  annotations: {}
+
+ingress:
+  enabled: false
+  className: ""
+  annotations: {}
+  hosts:
+    - host: makerchecker.local
+      paths:
+        - path: /
+          pathType: Prefix
+  tls: []
+
+resources:
+  requests:
+    cpu: 100m
+    memory: 256Mi
+  limits:
+    memory: 512Mi
+
+podDisruptionBudget:
+  enabled: true
+  minAvailable: 1
+
+probes:
+  liveness:
+    initialDelaySeconds: 20
+    periodSeconds: 10
+    timeoutSeconds: 3
+    failureThreshold: 5
+  readiness:
+    initialDelaySeconds: 5
+    periodSeconds: 10
+    timeoutSeconds: 3
+    failureThreshold: 3
+
+podAnnotations: {}
+podLabels: {}
+nodeSelector: {}
+tolerations: []
+affinity: {}
+
+# Bundled Postgres. EVAL ONLY: single replica, no HA, no backups, single-role
+# owner connection. Production sets postgresql.enabled=false and supplies an
+# external managed Postgres via database.existingSecret.
+postgresql:
+  enabled: false
+  image: postgres:17-alpine
+  auth:
+    username: makerchecker
+    password: makerchecker
+    database: makerchecker
+  service:
+    port: 5432
+  persistence:
+    enabled: true
+    storageClassName: ""
+    size: 5Gi
+  resources:
+    requests:
+      cpu: 100m
+      memory: 256Mi


### PR DESCRIPTION
A production Helm chart at `deploy/helm/makerchecker` so a regulated buyer can deploy on Kubernetes — previously only docker-compose existed. It mirrors the compose / Dockerfile / `harden-db.sql` deployment contract exactly.

## Correctness (all rendered + verified)
- **Signing key on a PersistentVolumeClaim** at `MAKERCHECKER_DATA_DIR` — *not* an emptyDir. `instance.public_key_pem` is write-once, so a lost key permanently breaks signed-bundle verification; the PVC + `fsGroup: 1000` lets the non-root uid write the `0600` key. The chart **fails loud** if persistence is disabled with no existing claim.
- **Strict `restricted` PodSecurity:** `runAsNonRoot` uid/gid/fsGroup 1000, seccomp `RuntimeDefault`, `readOnlyRootFilesystem` + a `/tmp` tmpfs, `allowPrivilegeEscalation: false`, capabilities drop `[ALL]`. Matches the non-root image.
- **Probes:** liveness `/healthz` (DB-independent), readiness `/readyz`.
- **Two-role migrate+harden** as a `pre-install,pre-upgrade` hook Job: a `migrate` initContainer (owner credential) runs before the `harden` container applies `harden-db.sql`; the server Deployment then runs as the non-owner `mc_app_runtime` with `MAKERCHECKER_SKIP_MIGRATE=1`. `hardened.enabled=false` is a single-role eval mode that skips it.
- **DATABASE_URL from a Secret;** external (default, recommended) vs a minimal eval-only bundled Postgres via `postgresql.enabled`.

## Verification
`helm lint --strict` + `helm template` render cleanly across all three example value sets (`external-db`, `bundled-eval`, `single-role`); the guard rejects a disabled PVC; the default (no DB configured) fails by design. A CI **`helm`** job runs the same lint+template on every PR.

Three example value sets + `deploy/helm/README.md`; the main README links the chart.