### PR TITLE
feat(limits): generic windowed quota — cumulative caps across runs

### DIFF
--- a/packages/sdk/openapi.json
+++ b/packages/sdk/openapi.json
@@ -128,6 +128,66 @@
                                   "type": "string"
                                 }
                               }
+                            },
+                            "quotas": {
+                              "type": "array",
+                              "items": {
+                                "additionalProperties": false,
+                                "type": "object",
+                                "required": [
+                                  "key",
+                                  "max",
+                                  "window"
+                                ],
+                                "properties": {
+                                  "key": {
+                                    "minLength": 1,
+                                    "type": "string"
+                                  },
+                                  "field": {
+                                    "minLength": 1,
+                                    "type": "string"
+                                  },
+                                  "max": {
+                                    "minimum": 0,
+                                    "type": "number"
+                                  },
+                                  "window": {
+                                    "anyOf": [
+                                      {
+                                        "type": "string",
+                                        "enum": [
+                                          "session"
+                                        ]
+                                      },
+                                      {
+                                        "type": "string",
+                                        "enum": [
+                                          "day"
+                                        ]
+                                      },
+                                      {
+                                        "type": "string",
+                                        "enum": [
+                                          "week"
+                                        ]
+                                      },
+                                      {
+                                        "type": "string",
+                                        "enum": [
+                                          "month"
+                                        ]
+                                      },
+                                      {
+                                        "type": "string",
+                                        "enum": [
+                                          "lifetime"
+                                        ]
+                                      }
+                                    ]
+                                  }
+                                }
+                              }
                             }
                           }
                         },

--- a/packages/server/migrations/0009_quota_usage.sql
+++ b/packages/server/migrations/0009_quota_usage.sql
@@ -1,0 +1,28 @@
+-- Windowed quota accrual ledger. A per-skill quota (roles.limits.skills.<ref>
+-- .quotas[]) accumulates a quantity — a named input field, or 1 per call — over
+-- a time window that spans sessions and runs, denying when the running total
+-- plus the next call would exceed the ceiling. One row per ALLOWED proxy action
+-- that contributed; denied attempts never accrue, so the SUM reflects only what
+-- was permitted. The running total for a window is a SUM over these rows filtered
+-- by (agent, skill_ref, quota_key) and the window's time/session predicate.
+--
+-- amount is numeric (not integer) because a contribution may be a fractional
+-- field value, not just a count. proxy_action_id ties each accrual to the action
+-- it was authorized alongside (in the same transaction); session_id supports the
+-- "session" window. occurred_at is the accrual instant the time windows truncate.
+
+CREATE TABLE quota_usage (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  proxy_action_id uuid REFERENCES proxy_actions(id),
+  agent_id uuid NOT NULL REFERENCES agents(id),
+  session_id uuid REFERENCES proxy_sessions(id),
+  skill_ref text NOT NULL,
+  quota_key text NOT NULL,
+  amount numeric NOT NULL,
+  occurred_at timestamptz NOT NULL DEFAULT now()
+);
+
+-- Serves the windowed SUM: lookup is by (agent, skill_ref, quota_key) with a
+-- range/order on occurred_at for the day/week/month/lifetime windows.
+CREATE INDEX quota_usage_lookup_idx
+  ON quota_usage (agent_id, skill_ref, quota_key, occurred_at);

--- a/packages/server/src/api/admin-routes.ts
+++ b/packages/server/src/api/admin-routes.ts
@@ -79,6 +79,29 @@ const SkillLimitConfig = Type.Object(
         { additionalProperties: false },
       ),
     ),
+    // Windowed quotas: a running total of `field` (or a count when omitted)
+    // accrued across this skill's allowed invocations within `window`, denied
+    // when it would exceed `max`. The window enum is fixed; the runtime maps it
+    // to a SQL truncation unit by lookup (never interpolating the raw value).
+    quotas: Type.Optional(
+      Type.Array(
+        Type.Object(
+          {
+            key: Type.String({ minLength: 1 }),
+            field: Type.Optional(Type.String({ minLength: 1 })),
+            max: Type.Number({ minimum: 0 }),
+            window: Type.Union([
+              Type.Literal("session"),
+              Type.Literal("day"),
+              Type.Literal("week"),
+              Type.Literal("month"),
+              Type.Literal("lifetime"),
+            ]),
+          },
+          { additionalProperties: false },
+        ),
+      ),
+    ),
   },
   { additionalProperties: false },
 );

--- a/packages/server/src/api/admin.integration.test.ts
+++ b/packages/server/src/api/admin.integration.test.ts
@@ -254,6 +254,83 @@ describe("roles", () => {
     expect(back.json().role.limits).toEqual(limits);
   });
 
+  it("saves per-skill windowed quotas verbatim (amount, count, every window)", async () => {
+    // Quotas persist exactly as written so the runtime windowed SUM enforces the
+    // operator's intent. Covers an amount quota, a count quota (no field), and
+    // each window literal in the fixed enum.
+    const limits = {
+      skills: {
+        "px-quota@1": {
+          quotas: [
+            { key: "monthly_amount", field: "amount", window: "month", max: 1000 },
+            { key: "daily_tokens", field: "tokens", window: "day", max: 100000 },
+            { key: "weekly_count", window: "week", max: 10 },
+            { key: "per_session_rows", field: "rows", window: "session", max: 5000 },
+            { key: "ever", window: "lifetime", max: 1 },
+          ],
+        },
+      },
+    };
+    const res = await app.inject({
+      method: "POST",
+      url: "/api/roles",
+      headers: auth,
+      payload: { name: "quota-grant-role", limits },
+    });
+    expect(res.statusCode).toBe(201);
+    expect(res.json().role.limits).toEqual(limits);
+    const back = await app.inject({
+      method: "GET",
+      url: `/api/roles/${res.json().role.id}`,
+      headers: auth,
+    });
+    expect(back.json().role.limits).toEqual(limits);
+  });
+
+  it("400s every malformed quota shape before save", async () => {
+    // A malformed quota would either silently never enforce or install a bogus
+    // ceiling; the strict write schema must reject all of these BEFORE save.
+    const sk = (cfg: unknown) => ({ skills: { "pay@1": cfg } });
+    const malformed: Array<[string, unknown]> = [
+      // quotas must be an array of objects.
+      ["quotas is an object", sk({ quotas: { key: "k", max: 1, window: "day" } })],
+      ["quotas is a string", sk({ quotas: "k" })],
+      // key is required and non-empty.
+      ["quota missing key", sk({ quotas: [{ max: 1, window: "day" }] })],
+      ["quota empty key", sk({ quotas: [{ key: "", max: 1, window: "day" }] })],
+      // max is required, numeric, non-negative.
+      ["quota missing max", sk({ quotas: [{ key: "k", window: "day" }] })],
+      ["quota max is a string", sk({ quotas: [{ key: "k", max: "1", window: "day" }] })],
+      ["quota max is negative", sk({ quotas: [{ key: "k", max: -1, window: "day" }] })],
+      ["quota max is null", sk({ quotas: [{ key: "k", max: null, window: "day" }] })],
+      // window is required and must be one of the fixed enum literals.
+      ["quota missing window", sk({ quotas: [{ key: "k", max: 1 }] })],
+      ["quota window not in enum", sk({ quotas: [{ key: "k", max: 1, window: "year" }] })],
+      ["quota window is a number", sk({ quotas: [{ key: "k", max: 1, window: 1 }] })],
+      // field, when present, must be a non-empty string.
+      ["quota field is empty", sk({ quotas: [{ key: "k", field: "", max: 1, window: "day" }] })],
+      ["quota field is a number", sk({ quotas: [{ key: "k", field: 7, max: 1, window: "day" }] })],
+      // unknown nested key (additionalProperties: false).
+      [
+        "quota has an unknown nested key",
+        sk({ quotas: [{ key: "k", max: 1, window: "day", extra: 1 }] }),
+      ],
+    ];
+    for (const [label, limits] of malformed) {
+      const res = await app.inject({
+        method: "POST",
+        url: "/api/roles",
+        headers: auth,
+        payload: { name: `quotabad-${label.replace(/[^a-z0-9]+/gi, "-")}`, limits },
+      });
+      expect(res.statusCode, `${label} should be rejected 400`).toBe(400);
+    }
+    const list = await app.inject({ method: "GET", url: "/api/roles", headers: auth });
+    expect(
+      list.json().roles.some((r: { name: string }) => r.name.startsWith("quotabad-")),
+    ).toBe(false);
+  });
+
   it("400s every malformed allowlist/pathScope shape before save", async () => {
     // Argument-grant analogue of the malformed-limits gate above: each case is an
     // allowlist or pathScope that the runtime would either deny silently at
@@ -357,6 +434,10 @@ describe("roles", () => {
       amountField: "amount_cents",
       allowlist: { field: "destination", values: ["0xSAFE", "0xTREASURY"] },
       pathScope: { field: "path", prefix: "/workspace/project" },
+      quotas: [
+        { key: "monthly_amount", field: "amount", window: "month", max: 1000 },
+        { key: "daily_calls", window: "day", max: 50 },
+      ],
     };
     const res = await app.inject({
       method: "POST",

--- a/packages/server/src/engine/limits.integration.test.ts
+++ b/packages/server/src/engine/limits.integration.test.ts
@@ -758,3 +758,279 @@ describe("proxy sessions honour per-skill argument grant policy (allowlist / pat
     expect(allowed.rows).toHaveLength(0);
   });
 });
+
+// ------------------------------------------------------------ windowed quotas
+
+/**
+ * Windowed quotas accrue across a skill's ALLOWED proxy invocations within a
+ * time/session window that spans runs, denying fail-closed when the running
+ * total plus this call's contribution would exceed the ceiling. Every
+ * guarantee is attacked: the ceiling itself, denied attempts NEVER accruing,
+ * a count quota with no field, and cross-session accrual within one window.
+ */
+describe("proxy sessions enforce windowed quotas (accrual across sessions/runs)", () => {
+  const ACTOR = { type: "user" as const, name: "quota-tester" };
+
+  async function quotaUsageRows(agentName: string, quotaKey: string): Promise<number> {
+    const { rows } = await db.pool.query<{ n: number }>(
+      `SELECT count(*)::int AS n FROM quota_usage q
+         JOIN agents a ON a.id = q.agent_id
+        WHERE a.name = $1 AND q.quota_key = $2`,
+      [agentName, quotaKey],
+    );
+    return rows[0]!.n;
+  }
+
+  it("a monthly amount quota denies once the running total would exceed max, and DENIED attempts never accrue", async () => {
+    // {field:"amount", window:"month", max:1000}: the canonical "spend cap" as a
+    // generic windowed quota. 300+300+300 (=900) all allowed; the next 300 would
+    // make 1200 > 1000 and is DENIED. A denied 5000 must NOT raise the total, so
+    // a later legitimate 100 (900+100=1000, inclusive) is still allowed.
+    const roleId = await seedRole("px-quota-amt-role", {
+      skills: {
+        "px-quota-amt@1": {
+          quotas: [{ key: "monthly_amount", field: "amount", window: "month", max: 1000 }],
+        },
+      },
+    });
+    await seedAgent("px-quota-amt-agent", roleId);
+    await seedSkill("px-quota-amt@1", async (i) => i);
+    await grant("px-quota-amt-agent", "px-quota-amt@1");
+    const session = await openSession(db.pool, { label: "quota-amt-session", actor: ACTOR });
+
+    const check = (amount: number) =>
+      checkAndAuthorize(db.pool, {
+        sessionId: session.id,
+        agentName: "px-quota-amt-agent",
+        skillRef: "px-quota-amt@1",
+        actor: ACTOR,
+        input: { amount },
+      });
+
+    expect(await check(300)).toMatchObject({ allowed: true }); // running 300
+    expect(await check(300)).toMatchObject({ allowed: true }); // running 600
+    expect(await check(300)).toMatchObject({ allowed: true }); // running 900
+
+    // 900 + 300 = 1200 > 1000 → DENIED.
+    expect(await check(300)).toMatchObject({ allowed: false, code: "limit_quota" });
+    // A huge denied attempt must not accrue toward the total.
+    expect(await check(5000)).toMatchObject({ allowed: false, code: "limit_quota" });
+
+    // The two denials accrued NOTHING: the total is still 900, so 900+100=1000
+    // (inclusive boundary) is allowed.
+    expect(await check(100)).toMatchObject({ allowed: true }); // running 1000
+    // …and now genuinely exhausted: 1000 + 1 = 1001 > 1000.
+    expect(await check(1)).toMatchObject({ allowed: false, code: "limit_quota" });
+
+    // Exactly four ALLOWED actions wrote a quota_usage row; no denial did.
+    expect(await quotaUsageRows("px-quota-amt-agent", "monthly_amount")).toBe(4);
+    const { rows } = await db.pool.query<{ used: string }>(
+      `SELECT coalesce(sum(q.amount),0) AS used FROM quota_usage q
+         JOIN agents a ON a.id = q.agent_id
+        WHERE a.name = 'px-quota-amt-agent' AND q.quota_key = 'monthly_amount'`,
+    );
+    expect(Number(rows[0]!.used)).toBe(1000);
+
+    // The denials were audited as limit violations via the proxy.
+    const viol = await db.pool.query<{ payload: Record<string, unknown> }>(
+      `SELECT payload FROM audit_events
+        WHERE event_type = 'enforcement.limit_violation'
+          AND entity_type = 'proxy_session' AND entity_id = $1
+        ORDER BY seq DESC LIMIT 1`,
+      [session.id],
+    );
+    expect(viol.rows[0]!.payload).toMatchObject({ via: "proxy", code: "limit_quota" });
+  });
+
+  it("an unreadable / negative quota input fails closed and does not accrue", async () => {
+    const roleId = await seedRole("px-quota-failclosed-role", {
+      skills: {
+        "px-quota-fc@1": {
+          quotas: [{ key: "fc_amount", field: "amount", window: "lifetime", max: 1000 }],
+        },
+      },
+    });
+    await seedAgent("px-quota-fc-agent", roleId);
+    await seedSkill("px-quota-fc@1", async (i) => i);
+    await grant("px-quota-fc-agent", "px-quota-fc@1");
+    const session = await openSession(db.pool, { label: "quota-fc-session", actor: ACTOR });
+
+    const check = (input?: Record<string, unknown>) =>
+      checkAndAuthorize(db.pool, {
+        sessionId: session.id,
+        agentName: "px-quota-fc-agent",
+        skillRef: "px-quota-fc@1",
+        actor: ACTOR,
+        ...(input !== undefined ? { input } : {}),
+      });
+
+    // Missing field → unreadable (fail closed).
+    expect(await check()).toMatchObject({ allowed: false, code: "limit_quota_unreadable" });
+    expect(await check({ note: "no amount" })).toMatchObject({
+      allowed: false,
+      code: "limit_quota_unreadable",
+    });
+    // Non-numeric → unreadable.
+    expect(await check({ amount: "1000" })).toMatchObject({
+      allowed: false,
+      code: "limit_quota_unreadable",
+    });
+    // Negative → denied (cannot count DOWN a running total).
+    expect(await check({ amount: -1_000_000 })).toMatchObject({
+      allowed: false,
+      code: "limit_quota",
+    });
+
+    // None of the fail-closed denials accrued anything.
+    expect(await quotaUsageRows("px-quota-fc-agent", "fc_amount")).toBe(0);
+    // A legitimate call still works and accrues exactly one row.
+    expect(await check({ amount: 250 })).toMatchObject({ allowed: true });
+    expect(await quotaUsageRows("px-quota-fc-agent", "fc_amount")).toBe(1);
+  });
+
+  it("a pure-count quota (no field) per day denies the 3rd call", async () => {
+    // {window:"day", max:2} with no field: each allowed call contributes 1.
+    const roleId = await seedRole("px-quota-count-role", {
+      skills: {
+        "px-quota-count@1": { quotas: [{ key: "daily_calls", window: "day", max: 2 }] },
+      },
+    });
+    await seedAgent("px-quota-count-agent", roleId);
+    await seedSkill("px-quota-count@1", async (i) => i);
+    await grant("px-quota-count-agent", "px-quota-count@1");
+    const session = await openSession(db.pool, { label: "quota-count-session", actor: ACTOR });
+
+    const check = () =>
+      checkAndAuthorize(db.pool, {
+        sessionId: session.id,
+        agentName: "px-quota-count-agent",
+        skillRef: "px-quota-count@1",
+        actor: ACTOR,
+        input: {}, // no field needed — a count quota ignores input
+      });
+
+    expect(await check()).toMatchObject({ allowed: true }); // 1 of 2
+    expect(await check()).toMatchObject({ allowed: true }); // 2 of 2
+    expect(await check()).toMatchObject({ allowed: false, code: "limit_quota" }); // 3rd denied
+
+    // Exactly two allowed rows, each amount 1 → total 2.
+    expect(await quotaUsageRows("px-quota-count-agent", "daily_calls")).toBe(2);
+  });
+
+  it("accrues ACROSS sessions within the same window (two sessions, same agent, sum together)", async () => {
+    // The month window spans sessions: the same agent's two sessions share one
+    // running total. max=1000; session A spends 600, session B then spends 500
+    // → 600+500=1100 > 1000 and B's 500 is denied; a 400 in B (600+400=1000) is
+    // allowed. Proves the SUM is NOT scoped to a single session for a month window.
+    const roleId = await seedRole("px-quota-xsess-role", {
+      skills: {
+        "px-quota-xsess@1": {
+          quotas: [{ key: "xsess_amount", field: "amount", window: "month", max: 1000 }],
+        },
+      },
+    });
+    await seedAgent("px-quota-xsess-agent", roleId);
+    await seedSkill("px-quota-xsess@1", async (i) => i);
+    await grant("px-quota-xsess-agent", "px-quota-xsess@1");
+
+    const sessionA = await openSession(db.pool, { label: "quota-xsessA", actor: ACTOR });
+    const sessionB = await openSession(db.pool, { label: "quota-xsessB", actor: ACTOR });
+    const check = (sessionId: string, amount: number) =>
+      checkAndAuthorize(db.pool, {
+        sessionId,
+        agentName: "px-quota-xsess-agent",
+        skillRef: "px-quota-xsess@1",
+        actor: ACTOR,
+        input: { amount },
+      });
+
+    expect(await check(sessionA.id, 600)).toMatchObject({ allowed: true }); // running 600
+    // Session B sees session A's accrual: 600 + 500 = 1100 > 1000 → denied.
+    expect(await check(sessionB.id, 500)).toMatchObject({ allowed: false, code: "limit_quota" });
+    // 600 + 400 = 1000 (inclusive) → allowed in session B.
+    expect(await check(sessionB.id, 400)).toMatchObject({ allowed: true }); // running 1000
+    // Exhausted across both sessions.
+    expect(await check(sessionA.id, 1)).toMatchObject({ allowed: false, code: "limit_quota" });
+
+    // Two allowed rows total (one per session), summing to 1000.
+    const { rows } = await db.pool.query<{ n: number; used: string }>(
+      `SELECT count(*)::int AS n, coalesce(sum(q.amount),0) AS used FROM quota_usage q
+         JOIN agents a ON a.id = q.agent_id
+        WHERE a.name = 'px-quota-xsess-agent' AND q.quota_key = 'xsess_amount'`,
+    );
+    expect(rows[0]!.n).toBe(2);
+    expect(Number(rows[0]!.used)).toBe(1000);
+  });
+
+  it("a SESSION-window quota does NOT bleed across sessions (the per-session counterpart)", async () => {
+    // Counterpart to the cross-session test: window:"session" scopes the SUM to
+    // session_id, so a second session starts fresh. max=2 rows/session.
+    const roleId = await seedRole("px-quota-sessonly-role", {
+      skills: {
+        "px-quota-sessonly@1": {
+          quotas: [{ key: "per_session", window: "session", max: 2 }],
+        },
+      },
+    });
+    await seedAgent("px-quota-sessonly-agent", roleId);
+    await seedSkill("px-quota-sessonly@1", async (i) => i);
+    await grant("px-quota-sessonly-agent", "px-quota-sessonly@1");
+
+    const sessionA = await openSession(db.pool, { label: "quota-sessonlyA", actor: ACTOR });
+    const sessionB = await openSession(db.pool, { label: "quota-sessonlyB", actor: ACTOR });
+    const check = (sessionId: string) =>
+      checkAndAuthorize(db.pool, {
+        sessionId,
+        agentName: "px-quota-sessonly-agent",
+        skillRef: "px-quota-sessonly@1",
+        actor: ACTOR,
+        input: {},
+      });
+
+    expect(await check(sessionA.id)).toMatchObject({ allowed: true }); // A: 1 of 2
+    expect(await check(sessionA.id)).toMatchObject({ allowed: true }); // A: 2 of 2
+    expect(await check(sessionA.id)).toMatchObject({ allowed: false, code: "limit_quota" }); // A exhausted
+    // Session B starts at zero — the session window does not see A's accrual.
+    expect(await check(sessionB.id)).toMatchObject({ allowed: true }); // B: 1 of 2
+    expect(await check(sessionB.id)).toMatchObject({ allowed: true }); // B: 2 of 2
+    expect(await check(sessionB.id)).toMatchObject({ allowed: false, code: "limit_quota" }); // B exhausted
+  });
+
+  it("a quota denial does NOT consume a co-configured per-skill invocation slot", async () => {
+    // A quota over its ceiling must deny WITHOUT burning the invocation cap (the
+    // denial returns before any proxy_actions row is written, exactly like the
+    // amount/allowlist denials). max invocations 2; quota count max 1.
+    const roleId = await seedRole("px-quota-combo-role", {
+      skills: {
+        "px-quota-combo@1": {
+          maxInvocationsPerRun: 2,
+          quotas: [{ key: "combo_calls", window: "lifetime", max: 1 }],
+        },
+      },
+    });
+    await seedAgent("px-quota-combo-agent", roleId);
+    await seedSkill("px-quota-combo@1", async (i) => i);
+    await grant("px-quota-combo-agent", "px-quota-combo@1");
+    const session = await openSession(db.pool, { label: "quota-combo-session", actor: ACTOR });
+    const check = () =>
+      checkAndAuthorize(db.pool, {
+        sessionId: session.id,
+        agentName: "px-quota-combo-agent",
+        skillRef: "px-quota-combo@1",
+        actor: ACTOR,
+        input: {},
+      });
+
+    expect(await check()).toMatchObject({ allowed: true }); // quota 1 of 1, invocation 1 of 2
+    // Quota exhausted → denied by limit_quota, NOT limit_invocations.
+    expect(await check()).toMatchObject({ allowed: false, code: "limit_quota" });
+    // The denial did not consume an invocation slot or accrue a quota row.
+    const actions = await db.pool.query<{ n: number }>(
+      `SELECT count(*)::int AS n FROM proxy_actions
+        WHERE session_id = $1 AND skill_ref = 'px-quota-combo@1' AND decision = 'allowed'`,
+      [session.id],
+    );
+    expect(actions.rows[0]!.n).toBe(1);
+    expect(await quotaUsageRows("px-quota-combo-agent", "combo_calls")).toBe(1);
+  });
+});

--- a/packages/server/src/engine/limits.security.test.ts
+++ b/packages/server/src/engine/limits.security.test.ts
@@ -4,6 +4,7 @@ import { createTestDb, type TestDb } from "../../test/test-db.js";
 import type { LocalSkillFn } from "./executor.js";
 import { GraphileWorkerBackend } from "./graphile-backend.js";
 import {
+  assertQuota,
   assertSkillLimits,
   checkSkillLimit,
   checkTokenBudget,
@@ -11,6 +12,8 @@ import {
   isPathWithinPrefix,
   LimitViolationError,
   normalizePath,
+  quotaContribution,
+  type Quota,
   type SkillLimitConfig,
 } from "./limits.js";
 import { publishFlowVersion } from "./flows.js";
@@ -111,6 +114,97 @@ describe("assertSkillLimits — negative-amount fail-open is closed", () => {
         expect((err as LimitViolationError).code).toBe("limit_amount_unreadable");
       }
     }
+  });
+});
+
+// ----------------------------------------------------------- quotas (pure)
+
+describe("quotaContribution — fail closed mirroring the amount guards", () => {
+  it("returns 1 for a count quota (no field)", () => {
+    const q: Quota = { key: "calls", max: 5, window: "day" };
+    expect(quotaContribution(q, {}, "skill@1")).toBe(1);
+    // A count quota ignores any input entirely — even a hostile one.
+    expect(quotaContribution(q, { field: -999, amount: "junk" }, "skill@1")).toBe(1);
+  });
+
+  it("reads the named field for a quantity quota", () => {
+    const q: Quota = { key: "amount", field: "amount", max: 1000, window: "month" };
+    expect(quotaContribution(q, { amount: 250 }, "pay@1")).toBe(250);
+    expect(quotaContribution(q, { amount: 0 }, "pay@1")).toBe(0);
+    expect(quotaContribution(q, { amount: 999.99 }, "pay@1")).toBe(999.99);
+  });
+
+  it("FAILS CLOSED as limit_quota_unreadable on a missing field", () => {
+    const q: Quota = { key: "amount", field: "amount", max: 1000, window: "month" };
+    try {
+      quotaContribution(q, { note: "no amount" }, "pay@1");
+      throw new Error("expected a LimitViolationError");
+    } catch (err) {
+      expect(err).toBeInstanceOf(LimitViolationError);
+      expect((err as LimitViolationError).code).toBe("limit_quota_unreadable");
+    }
+  });
+
+  it("FAILS CLOSED as limit_quota_unreadable on a non-number / non-finite field", () => {
+    const q: Quota = { key: "amount", field: "amount", max: 1000, window: "month" };
+    // A number disguised as a string is non-numeric → unreadable, exactly like
+    // the amount cap (never coerced into a value that could slip under a ceiling).
+    for (const bad of ["250", null, true, ["250"], { v: 250 }, Number.NaN, Number.POSITIVE_INFINITY]) {
+      try {
+        quotaContribution(q, { amount: bad }, "pay@1");
+        throw new Error("expected a LimitViolationError");
+      } catch (err) {
+        expect((err as LimitViolationError).code).toBe("limit_quota_unreadable");
+      }
+    }
+  });
+
+  it("FAILS CLOSED as limit_quota on a negative field (cannot count DOWN a total)", () => {
+    const q: Quota = { key: "amount", field: "amount", max: 1000, window: "month" };
+    // A negative contribution would lower a running total and let a later call
+    // slip under the ceiling — denied, mirroring the amount guard exactly.
+    for (const bad of [-0.01, -1, -1_000_000]) {
+      try {
+        quotaContribution(q, { amount: bad }, "pay@1");
+        throw new Error("expected a LimitViolationError");
+      } catch (err) {
+        expect((err as LimitViolationError).code).toBe("limit_quota");
+        expect((err as LimitViolationError).message).toContain("negative");
+      }
+    }
+  });
+});
+
+describe("assertQuota — inclusive ceiling at the boundary", () => {
+  const q: Quota = { key: "amount", field: "amount", max: 1000, window: "month" };
+
+  it("allows priorUsed + contribution exactly AT max (inclusive)", () => {
+    expect(() => assertQuota(q, 700, 300, "pay@1")).not.toThrow();
+    expect(() => assertQuota(q, 1000, 0, "pay@1")).not.toThrow();
+    expect(() => assertQuota(q, 0, 1000, "pay@1")).not.toThrow();
+  });
+
+  it("denies one unit OVER max", () => {
+    try {
+      assertQuota(q, 700, 300.01, "pay@1");
+      throw new Error("expected a LimitViolationError");
+    } catch (err) {
+      expect(err).toBeInstanceOf(LimitViolationError);
+      expect((err as LimitViolationError).code).toBe("limit_quota");
+      expect((err as LimitViolationError).message).toContain("amount");
+    }
+  });
+
+  it("denies when the prior total ALONE already meets max and one more is added", () => {
+    expect(() => assertQuota(q, 1000, 1, "pay@1")).toThrowError(LimitViolationError);
+    expect(() => assertQuota(q, 1200, 0, "pay@1")).toThrowError(/exceed/);
+  });
+
+  it("a count quota (contribution 1) denies the call that would step over max", () => {
+    const count: Quota = { key: "calls", max: 2, window: "day" };
+    expect(() => assertQuota(count, 0, 1, "x@1")).not.toThrow(); // 1 of 2
+    expect(() => assertQuota(count, 1, 1, "x@1")).not.toThrow(); // 2 of 2
+    expect(() => assertQuota(count, 2, 1, "x@1")).toThrowError(/limit/); // 3rd denied
   });
 });
 

--- a/packages/server/src/engine/limits.ts
+++ b/packages/server/src/engine/limits.ts
@@ -36,7 +36,9 @@ export type LimitViolationCode =
   | "limit_allowlist"
   | "limit_allowlist_unreadable"
   | "limit_path"
-  | "limit_path_unreadable";
+  | "limit_path_unreadable"
+  | "limit_quota"
+  | "limit_quota_unreadable";
 
 export class LimitViolationError extends Error {
   override name = "LimitViolationError";
@@ -64,6 +66,29 @@ export interface SkillLimitConfig {
    * is denied (fail closed). Models "may only touch files under the project dir".
    */
   pathScope?: { field: string; prefix: string };
+  /**
+   * Windowed quotas: each accumulates a quantity across this skill's ALLOWED
+   * invocations within a time window that spans sessions/runs, denying when the
+   * running total plus this call's contribution would exceed `max`. `field`
+   * names the input field summed (missing/non-numeric/negative fails closed);
+   * omitted, each call contributes 1 (a pure count). The window unit fixes the
+   * accrual scope. Models "at most N per day/week/month/session/ever".
+   */
+  quotas?: Quota[];
+}
+
+/**
+ * One windowed quota. `key` names the running total in storage (the accrual
+ * bucket); `field` is the input field summed into it, or a count when omitted;
+ * `max` is the inclusive ceiling; `window` fixes the time/session scope the sum
+ * is taken over. A monthly spend cap is just {field:"amount", window:"month"};
+ * the same shape expresses tokens/day, rows/session, or a pure count per week.
+ */
+export interface Quota {
+  key: string;
+  field?: string;
+  max: number;
+  window: "session" | "day" | "week" | "month" | "lifetime";
 }
 
 /**
@@ -271,6 +296,58 @@ export function assertSkillLimits(
           `prefix "${prefix}" — denied`,
       );
     }
+  }
+}
+
+/**
+ * This call's contribution to a quota's running total. With `field` set, reads
+ * the named input field (mirroring the amount cap's guards exactly): missing,
+ * non-number, or non-finite fails closed as unreadable; negative is rejected so
+ * a "-1,000,000" can never count DOWN a running total and slip under a ceiling.
+ * Without `field`, the call counts as 1 (a pure invocation count).
+ */
+export function quotaContribution(
+  quota: Quota,
+  input: Record<string, unknown>,
+  skillRef: string,
+): number {
+  if (quota.field === undefined) return 1;
+  const value = input[quota.field];
+  if (typeof value !== "number" || !Number.isFinite(value)) {
+    throw new LimitViolationError(
+      "limit_quota_unreadable",
+      `skill "${skillRef}" has quota "${quota.key}" on "${quota.field}" but the input ` +
+        `field is missing or non-numeric — denied (fail closed)`,
+    );
+  }
+  if (value < 0) {
+    throw new LimitViolationError(
+      "limit_quota",
+      `skill "${skillRef}" quota "${quota.key}" contribution ${value} is negative — ` +
+        `denied (fail closed)`,
+    );
+  }
+  return value;
+}
+
+/**
+ * Decides whether one more contribution fits under a quota's ceiling, given the
+ * total ALREADY accrued in its window. Inclusive: priorUsed + contribution ==
+ * max is allowed; strictly over denies. The caller supplies priorUsed as the
+ * windowed SUM of prior allowed contributions (denied attempts never accrued).
+ */
+export function assertQuota(
+  quota: Quota,
+  priorUsed: number,
+  contribution: number,
+  skillRef: string,
+): void {
+  if (priorUsed + contribution > quota.max) {
+    throw new LimitViolationError(
+      "limit_quota",
+      `skill "${skillRef}" quota "${quota.key}" (${quota.window}) would exceed its limit: ` +
+        `used ${priorUsed} + ${contribution} > ${quota.max}`,
+    );
   }
 }
 

--- a/packages/server/src/proxy/service.ts
+++ b/packages/server/src/proxy/service.ts
@@ -2,7 +2,14 @@ import type { Pool, PoolClient } from "pg";
 
 import { recordEvent, type Actor } from "../audit/writer.js";
 import { checkSodConflict, parseSkillRef } from "../engine/enforcement.js";
-import { assertSkillLimits, getRoleLimits, LimitViolationError } from "../engine/limits.js";
+import {
+  assertQuota,
+  assertSkillLimits,
+  getRoleLimits,
+  LimitViolationError,
+  quotaContribution,
+  type Quota,
+} from "../engine/limits.js";
 import { resolveRedactionHook, type RedactionHook } from "../llm/redaction.js";
 
 /**
@@ -41,7 +48,9 @@ export type ProxyDenialCode =
   | "limit_allowlist"
   | "limit_allowlist_unreadable"
   | "limit_path"
-  | "limit_path_unreadable";
+  | "limit_path_unreadable"
+  | "limit_quota"
+  | "limit_quota_unreadable";
 
 export type ProxyCheckResult =
   | { allowed: true; checkId: string }
@@ -70,6 +79,55 @@ export interface ProxySessionRow {
 
 const SESSION_COLUMNS =
   "id, label, external_ref, status, created_by_user_id, created_at, closed_at";
+
+// Fixed lookup from the validated window enum to a Postgres date_trunc unit.
+// The raw window value is NEVER interpolated into SQL: only these literal
+// constants reach the query string, so a quota window cannot inject. "session"
+// and "lifetime" use no time predicate (session id filter / no filter), so they
+// have no trunc unit here.
+const QUOTA_WINDOW_TRUNC: Record<Quota["window"], "day" | "week" | "month" | null> = {
+  session: null,
+  day: "day",
+  week: "week",
+  month: "month",
+  lifetime: null,
+};
+
+/**
+ * The total already accrued toward a quota in its window, summed from
+ * quota_usage over (agent, skill_ref, quota_key) plus the window predicate:
+ * "session" filters to this session; "day"/"week"/"month" filter to
+ * occurred_at >= date_trunc(<unit>, now()); "lifetime" applies no time filter.
+ * The trunc unit comes from a fixed lookup, never from the raw enum value.
+ */
+async function quotaPriorUsed(
+  client: PoolClient,
+  args: { agentId: string; sessionId: string; skillRef: string; quota: Quota },
+): Promise<number> {
+  const { agentId, sessionId, skillRef, quota } = args;
+  const base =
+    "SELECT coalesce(sum(amount), 0) AS used FROM quota_usage " +
+    "WHERE agent_id = $1 AND skill_ref = $2 AND quota_key = $3";
+  let rows: { used: string }[];
+  if (quota.window === "session") {
+    ({ rows } = await client.query<{ used: string }>(`${base} AND session_id = $4`, [
+      agentId,
+      skillRef,
+      quota.key,
+      sessionId,
+    ]));
+  } else if (quota.window === "lifetime") {
+    ({ rows } = await client.query<{ used: string }>(base, [agentId, skillRef, quota.key]));
+  } else {
+    // Only a literal trunc unit from the fixed lookup is interpolated.
+    const unit = QUOTA_WINDOW_TRUNC[quota.window]!;
+    ({ rows } = await client.query<{ used: string }>(
+      `${base} AND occurred_at >= date_trunc('${unit}', now())`,
+      [agentId, skillRef, quota.key],
+    ));
+  }
+  return Number(rows[0]!.used);
+}
 
 async function inTx<T>(pool: Pool, fn: (client: PoolClient) => Promise<T>): Promise<T> {
   const client = await pool.connect();
@@ -258,6 +316,24 @@ export async function checkAndAuthorize(
       );
       try {
         assertSkillLimits(skillLimits, prior.rows[0]!.n, input.input ?? {}, input.skillRef);
+        // Windowed quotas: per quota, this call's contribution (fails closed on
+        // missing/non-numeric/negative input) plus the total already accrued in
+        // its window must not exceed the ceiling. The accrual SUM counts only
+        // prior ALLOWED actions (denied attempts never wrote a quota_usage row),
+        // so a denial here cannot itself raise the running total. The matching
+        // INSERTs happen only on allow, below, in this same transaction.
+        if (skillLimits.quotas) {
+          for (const quota of skillLimits.quotas) {
+            const contribution = quotaContribution(quota, input.input ?? {}, input.skillRef);
+            const priorUsed = await quotaPriorUsed(client, {
+              agentId: agent.id,
+              sessionId: input.sessionId,
+              skillRef: input.skillRef,
+              quota,
+            });
+            assertQuota(quota, priorUsed, contribution, input.skillRef);
+          }
+        }
       } catch (err) {
         if (err instanceof LimitViolationError) {
           return deny(err.code, err.message, agent, skill.id);
@@ -273,6 +349,22 @@ export async function checkAndAuthorize(
       [input.sessionId, agent.id, agent.role_id, skill.id, input.skillRef],
     );
     const checkId = action.rows[0]!.id;
+    // Accrue each quota's contribution against this ALLOWED action, in the same
+    // transaction as the proxy_actions row. Only on allow, only for configured
+    // quotas: a denial returned before this point wrote no quota_usage row, so
+    // denied attempts never count toward any running total. Re-derives the
+    // contribution with the same fail-closed guards used in the check above.
+    if (skillLimits?.quotas) {
+      for (const quota of skillLimits.quotas) {
+        const contribution = quotaContribution(quota, input.input ?? {}, input.skillRef);
+        await client.query(
+          `INSERT INTO quota_usage
+             (proxy_action_id, agent_id, session_id, skill_ref, quota_key, amount, occurred_at)
+           VALUES ($1, $2, $3, $4, $5, $6, now())`,
+          [checkId, agent.id, input.sessionId, input.skillRef, quota.key, contribution],
+        );
+      }
+    }
     await recordEvent(client, {
       eventType: "proxy.check.allowed",
       actor: input.actor,


### PR DESCRIPTION
Adds a generic **windowed quota** to the limit engine: a per-skill quota accumulates a numeric quantity (a named input field, or 1 per call) over a time window that spans sessions and runs, and denies **fail-closed** when the running total plus the next call would exceed the ceiling.

A monthly spend cap is one instantiation — `{ key: "monthly-spend", field: "amount", window: "month", max: 1000 }` — and the same primitive expresses `tokens/day`, `rows/session`, or a plain count per week. It is the cumulative, cross-run counterpart to the existing per-run `maxInvocationsPerRun` / `maxAmountPerInvocation`.

## Changes
- `engine/limits.ts`: `Quota` type; `quotaContribution()` (fail-closed: missing/non-numeric → `limit_quota_unreadable`, negative → `limit_quota`, no field → count 1) and `assertQuota()` (inclusive ceiling).
- `api/admin-routes.ts`: `quotas` added to the `SkillLimitConfig` TypeBox; persisted verbatim.
- `migration 0009_quota_usage.sql`: append-only accrual ledger; SUM keyed by `(agent, skill_ref, quota_key)` + window predicate.
- `proxy/service.ts`: windowed-SUM enforcement and accrual inside the existing per-skill limit transaction. **Denied attempts never write a `quota_usage` row**, so a denial can't raise the running total. The window→`date_trunc` mapping is a fixed lookup over the validated enum — no SQL injection surface; all keys are bound params.

## Tests
61 unit + 30 limits-integration + admin-schema tests: sums that cross the ceiling deny; denied attempts don't accrue; cross-session accrual within a window; session-window isolation; count quotas; fail-closed on unreadable input; malformed-config rejected at write time. Full server suite green; no coverage threshold lowered.