### PR TITLE
feat(sdk): expose SoD constraints via client.sod

### DIFF
--- a/packages/sdk/src/index.test.ts
+++ b/packages/sdk/src/index.test.ts
@@ -219,6 +219,24 @@ describe("grants", () => {
   });
 });
 
+describe("sod", () => {
+  it("creates and revokes SoD constraints", async () => {
+    const f = mockFetch(201, { sodConstraint: { id: "sod-1" } });
+    const client = createClient({ baseUrl: "http://api.example", fetch: f });
+
+    await client.sod.create({ roleAId: "ro-a", roleBId: "ro-b", description: "maker cannot check" });
+    expect(lastCall(f).url).toBe("http://api.example/api/sod-constraints");
+    expect(JSON.parse(lastCall(f).init.body as string)).toEqual({
+      roleAId: "ro-a",
+      roleBId: "ro-b",
+      description: "maker cannot check",
+    });
+
+    await client.sod.revoke("sod-1");
+    expect(lastCall(f).url).toBe("http://api.example/api/sod-constraints/sod-1/revoke");
+  });
+});
+
 describe("audit", () => {
   it("verifies the chain", async () => {
     const f = mockFetch(200, { ok: true, count: 12, headHash: "abc" });

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -152,6 +152,16 @@ export interface Grant {
   revoked_at: string | null;
 }
 
+export interface SodConstraint {
+  id: string;
+  role_a_id: string;
+  role_b_id: string;
+  scope: string;
+  description: string;
+  created_at: string;
+  revoked_at: string | null;
+}
+
 export interface ProxySession {
   id: string;
   label: string;
@@ -312,6 +322,12 @@ export function createClient(options: ClientOptions) {
       create: (input: { roleId: string; skillId: string }) =>
         request<{ grant: Grant }>("POST", "/api/grants", input),
       revoke: (id: string) => request<{ grant: Grant }>("POST", `/api/grants/${id}/revoke`),
+    },
+
+    sod: {
+      create: (input: { roleAId: string; roleBId: string; description?: string }) =>
+        request<{ sodConstraint: SodConstraint }>("POST", "/api/sod-constraints", input),
+      revoke: (id: string) => request<{ sodConstraint: SodConstraint }>("POST", `/api/sod-constraints/${id}/revoke`),
     },
 
     audit: {


### PR DESCRIPTION
## What

Adds `client.sod.create({roleAId, roleBId, description?})` and `client.sod.revoke(id)` to `@makerchecker/sdk`, plus the `SodConstraint` type.

## Why

The server already exposes `POST /api/sod-constraints` (`createSodConstraint`) and the revoke route — they back the web admin's SoD controls. But the SDK never wrapped them, so SDK consumers had to seed segregation-of-duties with **raw SQL** against `sod_constraints`. That's the one genuinely employee-shaped control (maker ≠ checker) and it shouldn't require bypassing the SDK.

## Changes

- `client.sod.create` / `client.sod.revoke`, mirroring `client.grants`.
- `SodConstraint` interface matching the route's response shape.
- Unit test (mirrors the `grants` test). Verified against a live server: `{roleAId, roleBId, description}` → `201 {sodConstraint}`, self-constraint → `400`.

No server or schema changes; the routes are unchanged, so no OpenAPI drift.

🤖 Generated with [Claude Code](https://claude.com/claude-code)