### PR TITLE
Publish Python SDK to PyPI on version tags

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,21 +1,28 @@
 name: release
 
-# Publishes the public npm packages (@makerchecker/sdk and the connectors) when a
-# version tag is pushed. The release flow is just:
+# Publishes the public npm packages (@makerchecker/sdk and the connectors) and
+# the Python SDK (makerchecker on PyPI) when a version tag is pushed. The
+# release flow is just:
 #
 #     git tag v1.2.3 && git push origin v1.2.3
 #
-# The job sets every package's version FROM THE TAG before publishing, so you
-# never hand-edit package.json. Without this, a tag silently no-ops: package.json
-# stays at its old version, which is already on the registry, so pnpm skips it and
-# the run goes green having published nothing (this is what made v1.0.1..v1.0.3
-# ship nothing while package.json sat at 1.0.0).
+# Each job sets the package version FROM THE TAG before publishing, so you
+# never hand-edit package.json or pyproject.toml. Without this, a tag silently
+# no-ops: package.json stays at its old version, which is already on the
+# registry, so pnpm skips it and the run goes green having published nothing
+# (this is what made v1.0.1..v1.0.3 ship nothing while package.json sat at
+# 1.0.0).
 #
-# Auth: add an npm "Automation" access token as the repository secret NPM_TOKEN
-# (Settings -> Secrets and variables -> Actions -> New repository secret).
-# `--provenance` attaches a signed build attestation linking each published
-# package to this exact workflow run. `pnpm -r publish` skips private packages
-# (server, web, shared) and any version already on the registry.
+# Auth (npm): add an npm "Automation" access token as the repository secret
+# NPM_TOKEN (Settings -> Secrets and variables -> Actions -> New repository
+# secret). `--provenance` attaches a signed build attestation linking each
+# published package to this exact workflow run. `pnpm -r publish` skips private
+# packages (server, web, shared) and any version already on the registry.
+#
+# Auth (PyPI): no token. The publish-pypi job authenticates via PyPI Trusted
+# Publishing (OIDC): on pypi.org, the `makerchecker` project must list this
+# repo + `release.yml` as a trusted publisher. The `id-token: write` permission
+# below is what lets the job mint the short-lived OIDC token.
 
 on:
   push:
@@ -23,7 +30,7 @@ on:
 
 permissions:
   contents: read
-  id-token: write # required to generate npm provenance
+  id-token: write # required for npm provenance and PyPI Trusted Publishing
 
 jobs:
   publish:
@@ -61,3 +68,34 @@ jobs:
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
           NPM_CONFIG_PROVENANCE: "true"
+
+  publish-pypi:
+    runs-on: ubuntu-latest
+    environment: pypi # bind the OIDC claim; also configure this on pypi.org
+    defaults:
+      run:
+        working-directory: packages/sdk-python
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: astral-sh/setup-uv@v7
+        with:
+          python-version: "3.12"
+
+      # Same rule as the npm job: the tag is the single source of truth for the
+      # version. The grep makes a failed rewrite fail the job instead of
+      # silently republishing the old pyproject.toml version.
+      - name: Set package version from the tag
+        run: |
+          VERSION="${GITHUB_REF_NAME#v}"
+          echo "Releasing makerchecker $VERSION"
+          sed -i "s/^version = \".*\"$/version = \"$VERSION\"/" pyproject.toml
+          grep -Fx "version = \"$VERSION\"" pyproject.toml
+
+      - name: Build sdist and wheel
+        run: uv build
+
+      - name: Publish to PyPI via Trusted Publishing
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          packages-dir: packages/sdk-python/dist

--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@ Connectors keep your tool's name, description, and schema:
 
 - **LangChain** — `governLangChainTool` returns a `DynamicStructuredTool`. See [examples/connectors/langchain](examples/connectors/langchain/README.md).
 - **Claude Agent SDK** — `governClaudeTool` returns an `SdkMcpToolDefinition` for `createSdkMcpServer`. See [packages/connector-claude-agent](packages/connector-claude-agent/README.md).
-- **Python** (CrewAI, LangChain, LlamaIndex, AutoGen) — `create_client` then `governed_tool`; `pip install makerchecker`. See [packages/sdk-python](packages/sdk-python/README.md).
+- **Python** (CrewAI, LangChain, LlamaIndex, AutoGen) — `create_client` then `governed_tool`; `pip install "makerchecker @ git+https://github.com/sammysltd/makerchecker#subdirectory=packages/sdk-python"` (plain `pip install makerchecker` from PyPI works from the next tagged release). See [packages/sdk-python](packages/sdk-python/README.md).
 
 ## Audit and verification
 

--- a/packages/sdk-python/README.md
+++ b/packages/sdk-python/README.md
@@ -5,10 +5,10 @@ A typed HTTP client for a running MakerChecker server, plus the `governed_tool` 
 ## Install
 
 ```bash
-pip install makerchecker
+pip install "makerchecker @ git+https://github.com/sammysltd/makerchecker#subdirectory=packages/sdk-python"
 ```
 
-Python 3.10+. Runtime dependency: `httpx`.
+Plain `pip install makerchecker` from PyPI works from the next tagged release. Python 3.10+. Runtime dependency: `httpx`.
 
 ## Use
 


### PR DESCRIPTION
## What changed

- **`.github/workflows/release.yml`**: added a `publish-pypi` job triggered by the same `v*` tag as the npm job. It rewrites the `pyproject.toml` version from the tag (with a `grep -Fx` guard so a failed rewrite fails the job instead of silently republishing the old version — same lesson as the npm job's set-version-from-tag step from #53), builds the sdist and wheel with `uv build` (hatchling backend, `astral-sh/setup-uv@v7` as already used in `ci.yml`), and publishes via `pypa/gh-action-pypi-publish@release/v1` using **PyPI Trusted Publishing (OIDC)** — no long-lived token, reusing the workflow's existing `id-token: write` permission. The job runs in a `pypi` environment so the OIDC claim can be pinned.
- **`README.md` (~line 113) and `packages/sdk-python/README.md`**: until the first post-merge tagged release exists, both now show the install that actually works today — `pip install "makerchecker @ git+https://github.com/sammysltd/makerchecker#subdirectory=packages/sdk-python"` — with a one-line note that plain `pip install makerchecker` works from the next tagged release.

## Why

Audit finding: both READMEs instruct `pip install makerchecker`, but the package was never published — `https://pypi.org/pypi/makerchecker/json` returns 404, and `release.yml` publishes only the npm packages. The documented Python install path was dead.

## Manual step required before the next tag (~5 minutes)

PyPI Trusted Publishing must be configured once, which also reserves the name:

1. Log in to pypi.org, go to **Your account -> Publishing** (https://pypi.org/manage/account/publishing/).
2. Under **Add a new pending publisher** (GitHub tab), enter exactly:
   - **PyPI project name:** `makerchecker`
   - **Owner:** `sammysltd`
   - **Repository name:** `MakerChecker`
   - **Workflow name:** `release.yml`
   - **Environment name:** `pypi`
3. Click **Add**. This creates a *pending* publisher that reserves the `makerchecker` name; the project is created automatically on the first successful publish, and the pending publisher becomes a normal trusted publisher. No token or GitHub-side setup is needed (the `pypi` environment is auto-created on the first workflow run; optionally add protection rules to it under repo Settings -> Environments).

Then `git tag v1.x.y && git push origin v1.x.y` publishes to npm and PyPI in one run.

## How it was verified

- Local build of the SDK in a clean venv (`python -m build`, hatchling backend): `Successfully built makerchecker-1.0.0.tar.gz and makerchecker-1.0.0-py3-none-any.whl`; the wheel contains `makerchecker/{__init__,_client,_governance}.py` + `py.typed` + LICENSE, installs, and `from makerchecker import create_client, governed_tool` succeeds.
- Simulated the set-version step with a fake `v1.2.3` tag ref: sed rewrite + `grep -Fx` guard pass.
- Verified the documented git install against the real repo in a clean venv: `pip install "makerchecker @ git+https://github.com/sammysltd/makerchecker#subdirectory=packages/sdk-python"` -> import OK.
- `actionlint 1.7.7` on the modified `release.yml`: 0 findings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)