### PR TITLE
Fail closed on unexercised requirements; honest obligations output

### DIFF
--- a/packages/obligations/README.md
+++ b/packages/obligations/README.md
@@ -35,12 +35,24 @@ mc-obligations check --bundle run-evidence.json --profile gamp5 --strict
 EU GMP Annex 11 (Computerised Systems)
 Bundle: chain VERIFIED (8 events)
 
-  ✓ 9     MET  (seq 1, 7, 3)   Audit Trails
-  ✓ 12.1  MET  (seq 4)         Security — access restricted to authorised persons
-  ✓ 14    MET  (seq 6)         Electronic Signature — permanently linked, with time and date
+  ✓ 4  MET
+      Validation
+      note: Partial: tamper-evidence is provided; lifecycle validation (URS/FS/IQ/OQ/PQ) is the operator's process — see the GxP validation kit.
+  ✓ 9  MET  (seq 1, 7, 3)
+      Audit Trails
+      note: Every agent action and governance decision is recorded in the hash-chained log.
+  ✓ 12.1  MET  (seq 4)
+      Security — access restricted to authorised persons
   ...
   6 met, 0 not-evidenced, 0 not-applicable
+
+  Scope: this profile assesses 5 of 6 mapped clauses in full; 1 is in part the operator's process, not evidenced by this tool.
+  Clauses of the framework not mapped in this profile are not assessed here.
 ```
+
+Clause titles carry the regulation's own words; how MakerChecker evidences the
+clause (and any *Partial* caveat about what remains the operator's process) is
+in the clause's `note`, printed with every result.
 
 ## How it works
 
@@ -48,7 +60,8 @@ Bundle: chain VERIFIED (8 events)
    chain does not verify, the report says so and its findings must not be relied
    upon — evidence only counts on an intact chain.
 2. Each clause carries an `evidence` predicate over the audit events
-   (`eventType`, `payloadMatch`, `anyOf`/`allOf`, `chainVerified`). A clause is:
+   (`eventType`, `payloadMatch`, `payloadHas`, `anyOf`/`allOf`,
+   `chainVerified`). A clause is:
    - **MET** when concrete events prove it — their `seq` numbers are cited;
    - **NOT_EVIDENCED** when the activity occurred but the evidence is absent;
    - **NOT_APPLICABLE** when the clause's precondition never arose in this run

--- a/packages/obligations/profiles/annex-11.json
+++ b/packages/obligations/profiles/annex-11.json
@@ -10,6 +10,7 @@
       "requirement": "The system supports evidence that records are accurate and alterations are detectable.",
       "applicableWhen": "always",
       "evidence": { "chainVerified": true },
+      "partial": true,
       "note": "Partial: tamper-evidence is provided; lifecycle validation (URS/FS/IQ/OQ/PQ) is the operator's process — see the GxP validation kit."
     },
     {
@@ -36,14 +37,17 @@
     },
     {
       "id": "12.4",
-      "title": "Management of who can enter and change data; segregation of duties",
-      "requirement": "The person who prepares an action and the person who authorises it are separated.",
+      "title": "Management systems for data and for documents should be designed to record the identity of operators entering, changing, confirming or deleting data including date and time",
+      "requirement": "The identity of the operator entering, changing, confirming or deleting data is recorded, together with date and time.",
       "applicableWhen": "always",
-      "evidence": { "anyOf": [
-        { "eventType": "enforcement.sod_violation" },
-        { "eventType": "approval.decided" }
+      "evidence": { "allOf": [
+        { "chainVerified": true },
+        { "anyOf": [
+          { "eventType": "approval.decided", "payloadHas": ["decider"] },
+          { "eventType": "skill.invoked" }
+        ] }
       ] },
-      "note": "Segregation is enforced at runtime; a conflicting actor records enforcement.sod_violation, and gated actions are decided by a separate identity."
+      "note": "Every audit event records the acting identity (actor) and occurredAt (date and time) on a tamper-evident chain; approval.decided additionally carries the named decider. Segregation of duties is a separate MakerChecker control (runtime enforcement.sod_violation), not what this clause requires."
     },
     {
       "id": "14",

--- a/packages/obligations/profiles/part-11.json
+++ b/packages/obligations/profiles/part-11.json
@@ -10,6 +10,7 @@
       "requirement": "The system must be able to discern invalid or altered records.",
       "applicableWhen": "always",
       "evidence": { "chainVerified": true },
+      "partial": true,
       "note": "Partial: the hash chain lets any altered record be discerned (verification fails at the altered seq). Full computerised-system validation is the operator's process."
     },
     {
@@ -59,8 +60,8 @@
       "title": "Signature manifestations — printed name of the signer, date and time, and meaning of the signature",
       "requirement": "A signed record carries the signer, the time, and the meaning of the signature.",
       "applicableWhen": { "eventType": "approval.requested" },
-      "evidence": { "eventType": "approval.decided" },
-      "note": "approval.decided carries the decider, the decision (meaning), the reason, and occurredAt (time)."
+      "evidence": { "eventType": "approval.decided", "payloadHas": ["decider", "decision"] },
+      "note": "MET only when approval.decided actually carries the decider (signer) and the decision (meaning) in its payload, plus occurredAt (time); a decision event missing either field does not manifest a signature."
     },
     {
       "id": "11.70",

--- a/packages/obligations/scripts/test.mjs
+++ b/packages/obligations/scripts/test.mjs
@@ -1,10 +1,13 @@
 /**
  * Tests the obligations checker against (a) the proof-verifier's real signed
- * conformance bundle, and (b) a freshly-built signed bundle with no approvals,
+ * conformance bundle, (b) a freshly-built signed bundle with no approvals,
  * so all three statuses (MET, NOT_EVIDENCED, NOT_APPLICABLE) are exercised on a
- * verifying chain.
+ * verifying chain, (d) a decision event without a named signer (Part 11 11.50
+ * must NOT be evidenced), and (e) the CLI text output: per-clause notes and the
+ * scope footer.
  */
 
+import { spawnSync } from "node:child_process";
 import { createHash, generateKeyPairSync, sign as edSign } from "node:crypto";
 import { readFileSync } from "node:fs";
 import { dirname, join } from "node:path";
@@ -22,16 +25,12 @@ const GENESIS_PREFIX = "makerchecker-genesis:";
 let failures = 0;
 const check = (cond, msg) => { if (cond) { console.log(`  ok  ${msg}`); } else { console.error(`  FAIL ${msg}`); failures++; } };
 
-// ---- Build a minimal signed full bundle with NO approvals ----
-function buildNoApprovalBundle() {
+// ---- Build a minimal signed full bundle from event specs ----
+function buildSignedBundle(specs) {
   const instanceId = "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa";
   const { privateKey, publicKey } = generateKeyPairSync("ed25519");
   const publicKeyPem = publicKey.export({ type: "spki", format: "pem" }).toString();
   const hashInput = (e) => ({ id: e.id, occurredAt: e.occurred_at, actor: e.actor, eventType: e.event_type, entityType: e.entity_type, entityId: e.entity_id, runId: e.run_id, payload: e.payload, prevHash: e.prev_hash });
-  const specs = [
-    { id: "g", occurred_at: "2026-01-01T00:00:00.000Z", actor: { kind: "system" }, event_type: "audit.genesis", payload: { instanceId } },
-    { id: "s", occurred_at: "2026-01-01T00:00:01.000Z", actor: { kind: "agent", id: "a1" }, event_type: "skill.invoked", run_id: "r1", payload: { skill: "lookup@1" } },
-  ];
   let prev = sha(GENESIS_PREFIX + instanceId);
   const events = specs.map((s, i) => {
     const e = { seq: String(i + 1), id: s.id, occurred_at: s.occurred_at, actor: s.actor, event_type: s.event_type, entity_type: null, entity_id: null, run_id: s.run_id ?? null, payload: s.payload, prev_hash: prev };
@@ -44,6 +43,20 @@ function buildNoApprovalBundle() {
   const signature = edSign(null, Buffer.from(signingString, "utf8"), privateKey).toString("base64");
   return { manifest: { ...unsigned, signature }, events };
 }
+
+const INSTANCE = "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa";
+const buildNoApprovalBundle = () => buildSignedBundle([
+  { id: "g", occurred_at: "2026-01-01T00:00:00.000Z", actor: { kind: "system" }, event_type: "audit.genesis", payload: { instanceId: INSTANCE } },
+  { id: "s", occurred_at: "2026-01-01T00:00:01.000Z", actor: { kind: "agent", id: "a1" }, event_type: "skill.invoked", run_id: "r1", payload: { skill: "lookup@1" } },
+]);
+
+// An approval decided WITHOUT a named decider/decision in its payload: the
+// event exists, but it does not manifest a Part 11 signature.
+const buildAnonymousDecisionBundle = () => buildSignedBundle([
+  { id: "g", occurred_at: "2026-01-01T00:00:00.000Z", actor: { kind: "system" }, event_type: "audit.genesis", payload: { instanceId: INSTANCE } },
+  { id: "q", occurred_at: "2026-01-01T00:00:01.000Z", actor: { kind: "agent", id: "a1" }, event_type: "approval.requested", run_id: "r1", payload: { gate: "g1" } },
+  { id: "d", occurred_at: "2026-01-01T00:00:02.000Z", actor: { kind: "system" }, event_type: "approval.decided", run_id: "r1", payload: { note: "auto-decided, no signer recorded" } },
+]);
 
 // ---- Test A: real signed bundle with approvals, against Part 11 ----
 const validFull = JSON.parse(readFileSync(join(VECTORS, "valid-full.json"), "utf8"));
@@ -72,6 +85,24 @@ for (const id of ["part-11", "annex-11", "gamp5", "hipaa-164-312"]) {
   const r = await checkObligations(validFull, profile(id));
   check(r.clauses.length > 0 && r.reliable, `${id} profile runs and verifies`);
 }
+
+// ---- Test D: 11.50 requires the decider and decision fields, not just the event ----
+const d = await checkObligations(buildAnonymousDecisionBundle(), profile("part-11"));
+console.log("Test D — approval decided without a named signer vs Part 11:");
+check(d.reliable === true, "chain verifies");
+const dById = Object.fromEntries(d.clauses.map((c) => [c.id, c]));
+check(dById["11.50"].status === STATUS.NOT_EVIDENCED, "11.50 NOT_EVIDENCED when approval.decided lacks decider/decision fields");
+check(dById["11.70"].status === STATUS.MET, "11.70 record-linking still MET (the event is chained)");
+
+// ---- Test E: CLI text output prints notes and the scope footer ----
+console.log("Test E — CLI text output (annex-11):");
+const CLI = join(HERE, "..", "src", "cli.js");
+const e = spawnSync(process.execPath, [CLI, "check", "--bundle", join(VECTORS, "valid-full.json"), "--profile", "annex-11"], { encoding: "utf8" });
+check(e.status === 0, `CLI exits 0 on a verified bundle (got ${e.status})`);
+check(e.stdout.includes("note: Partial: tamper-evidence is provided"), "prints each clause's note under it (Partial caveat visible)");
+check(e.stdout.includes("Scope: this profile assesses 5 of 6 mapped clauses in full; 1 is in part the operator's process, not evidenced by this tool."), "prints the scope footer");
+check(e.stdout.includes("record the identity of operators entering, changing, confirming or deleting data"), "12.4 title carries the regulation text verbatim");
+check(!e.stdout.includes("Management of who can enter and change data"), "12.4 title no longer paraphrased as segregation of duties");
 
 console.log(failures ? `\n${failures} check(s) FAILED` : "\nall checks passed");
 process.exit(failures ? 1 : 0);

--- a/packages/obligations/src/checker.js
+++ b/packages/obligations/src/checker.js
@@ -31,7 +31,7 @@ export async function checkObligations(bundle, profile, opts = {}) {
       applicable = evalPredicate(idx, c.applicableWhen, ctx).met;
     }
     if (!applicable) {
-      return { id: c.id, title: c.title, requirement: c.requirement, status: STATUS.NOT_APPLICABLE, citedSeqs: [], note: c.note };
+      return { id: c.id, title: c.title, requirement: c.requirement, status: STATUS.NOT_APPLICABLE, citedSeqs: [], note: c.note, partial: c.partial === true };
     }
     const r = evalPredicate(idx, c.evidence, ctx);
     return {
@@ -41,6 +41,7 @@ export async function checkObligations(bundle, profile, opts = {}) {
       status: r.met ? STATUS.MET : STATUS.NOT_EVIDENCED,
       citedSeqs: r.seqs,
       note: c.note,
+      partial: c.partial === true,
     };
   });
 

--- a/packages/obligations/src/cli.js
+++ b/packages/obligations/src/cli.js
@@ -101,9 +101,14 @@ async function main() {
     for (const c of report.clauses) {
       process.stdout.write(`  ${ICON[c.status]} ${c.id}  ${c.status}${c.citedSeqs.length ? `  (seq ${c.citedSeqs.join(", ")})` : ""}\n`);
       process.stdout.write(`      ${c.title}\n`);
+      if (c.note) process.stdout.write(`      note: ${c.note}\n`);
     }
     const s = report.summary;
     process.stdout.write(`\n  ${s.MET} met, ${s.NOT_EVIDENCED} not-evidenced, ${s.NOT_APPLICABLE} not-applicable\n`);
+    const total = report.clauses.length;
+    const partial = report.clauses.filter((c) => c.partial).length;
+    process.stdout.write(`\n  Scope: this profile assesses ${total - partial} of ${total} mapped clauses in full; ${partial} ${partial === 1 ? "is" : "are"} in part the operator's process, not evidenced by this tool.\n`);
+    process.stdout.write(`  Clauses of the framework not mapped in this profile are not assessed here.\n`);
   }
 
   if (!report.chain.verified) process.exit(1);

--- a/packages/obligations/src/predicates.js
+++ b/packages/obligations/src/predicates.js
@@ -7,6 +7,11 @@
  *   { eventType: "approval.decided" }                          >=1 such event
  *   { eventType: "enforcement.blocked",
  *     payloadMatch: { code: "skill_not_granted" } }            >=1 matching payload
+ *   { eventType: "approval.decided",
+ *     payloadHas: ["decider", "decision"] }                    >=1 event whose payload
+ *                                                              carries these fields
+ *                                                              (present, non-null,
+ *                                                              non-empty string)
  *   { eventType: "...", minCount: 2 }                          at least N
  *   { anyOf: [ <pred>, ... ] }                                 any child MET
  *   { allOf: [ <pred>, ... ] }                                 all children MET
@@ -25,12 +30,20 @@ export function indexEvents(events) {
 const dedupe = (xs) => [...new Set(xs)];
 
 function matchLeaf(idx, pred) {
-  const list = idx.byType.get(pred.eventType) ?? [];
-  if (!pred.payloadMatch) return list;
-  return list.filter((e) => {
-    const p = e.payload ?? {};
-    return Object.entries(pred.payloadMatch).every(([k, v]) => p[k] === v);
-  });
+  let list = idx.byType.get(pred.eventType) ?? [];
+  if (pred.payloadMatch) {
+    list = list.filter((e) => {
+      const p = e.payload ?? {};
+      return Object.entries(pred.payloadMatch).every(([k, v]) => p[k] === v);
+    });
+  }
+  if (pred.payloadHas) {
+    list = list.filter((e) => {
+      const p = e.payload ?? {};
+      return pred.payloadHas.every((k) => p[k] !== undefined && p[k] !== null && p[k] !== "");
+    });
+  }
+  return list;
 }
 
 export function evalPredicate(idx, pred, ctx) {

--- a/packages/validation-kit/README.md
+++ b/packages/validation-kit/README.md
@@ -25,8 +25,27 @@ mc-validate run --bundle run-evidence.json --protocol agent-governance-baseline 
 mc-validate run --bundle run-evidence.json --protocol agent-governance-baseline --key instance-pubkey.pem --json
 ```
 
-Exit code `0` if the system **qualified**, `1` if not (a failed test, an
-uncovered requirement, or a chain that did not verify).
+Exit code `0` only if the system **qualified**: the chain verified, every
+executed test passed, and every user requirement was exercised and covered —
+or explicitly waived. Exit code `1` for anything else: a failed test, an
+uncovered requirement, a requirement the bundle never exercised
+(**fail-closed** — "not exercised" is a gap, not a pass), or a chain that did
+not verify.
+
+A requirement your evidence never exercised (e.g. `URS-004` fail-closed limits,
+when the run never hit a limit) makes the report **NOT QUALIFIED**. Either
+capture challenge-run evidence — drive an over-limit request so the refusal is
+recorded — and re-run, or record an explicit deviation:
+
+```bash
+mc-validate run --bundle run-evidence.json --protocol agent-governance-baseline \
+  --waive URS-004 --reason "Fail-closed limits challenge scheduled for OQ round 2 (CAPA-114)" \
+  --out validation-report.md
+```
+
+Every `--waive` requires a written `--reason`; the waiver is printed verbatim in
+the report's **Deviations** section for the named reviewers to accept or reject.
+A waiver never rescues a requirement whose tests executed and failed.
 
 ## What it produces
 
@@ -34,10 +53,12 @@ uncovered requirement, or a chain that did not verify).
 - **OQ** — operational: each control fires (deny-by-default, high-risk gate, segregation of duties, fail-closed limits).
 - **PQ** — performance: a representative governed run completes end-to-end with a signed decision.
 - **Requirements Traceability Matrix** — URS → FS → test → result, with a coverage verdict per requirement.
+- **Deviations** — any waived (unexercised) requirement, with its recorded reason.
 - **Qualification statement** and an **approval block** for the operator's named reviewers (maker-checker applies to the validation itself: author ≠ approver).
 
-A tampered or incomplete bundle cannot qualify — the report says **NOT
-QUALIFIED** and states why.
+A tampered or incomplete bundle cannot qualify, and neither can a run that
+never exercised a requirement — the report says **NOT QUALIFIED** and states
+why, unless the gap is an explicitly recorded deviation.
 
 ## Protocols
 
@@ -62,14 +83,19 @@ No LLM, no network, no producer access.
 
 ```js
 import { generateValidation, renderReport } from "@makerchecker/validation-kit";
-const result = await generateValidation(bundle, protocol, { expectedPublicKeyPem });
+const result = await generateValidation(bundle, protocol, {
+  expectedPublicKeyPem,
+  waivers: [{ urs: "URS-004", reason: "Limits challenge scheduled for OQ round 2 (CAPA-114)" }],
+});
 const markdown = renderReport(result);
 ```
 
 ## Test
 
 ```bash
-npm test   # qualifies a real signed run; confirms a tampered bundle does not qualify
+npm test   # fail-closed: an unexercised requirement does NOT qualify; a waiver
+           # records a deviation; a challenge run covering every URS qualifies;
+           # a tampered bundle never qualifies
 ```
 
 ## License

--- a/packages/validation-kit/scripts/test.mjs
+++ b/packages/validation-kit/scripts/test.mjs
@@ -1,25 +1,57 @@
 /**
- * Tests the validation-kit against the proof-verifier's real signed bundle:
- * the baseline protocol should qualify it (IQ/OQ/PQ pass, RTM covered), and the
- * rendered report must contain the expected sections.
+ * Tests the validation-kit fail-closed:
+ *   A  the real signed bundle (which never hits a limit) leaves URS-004
+ *      unexercised => NOT QUALIFIED, and the CLI exits 1;
+ *   A2 an explicit waiver (--waive/--reason) qualifies WITH a recorded deviation;
+ *   A3 a waiver never rescues a requirement whose tests executed and failed;
+ *   B  a tampered bundle never qualifies;
+ *   C  a signed challenge run that exercises every URS (including an over-limit
+ *      refusal for URS-004) fully qualifies with no waivers.
  */
 
+import { spawnSync } from "node:child_process";
+import { createHash, generateKeyPairSync, sign as edSign } from "node:crypto";
 import { readFileSync } from "node:fs";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 
+import { canonicalJson } from "../../proof-verifier/src/canonical-json.js";
 import { generateValidation, RESULT } from "../src/generate.js";
 import { renderReport } from "../src/report.js";
 
 const HERE = dirname(fileURLToPath(import.meta.url));
-const bundle = JSON.parse(readFileSync(join(HERE, "..", "..", "proof-verifier", "vectors", "valid-full.json"), "utf8"));
-const tampered = JSON.parse(readFileSync(join(HERE, "..", "..", "proof-verifier", "vectors", "tampered-payload.json"), "utf8"));
+const VECTORS = join(HERE, "..", "..", "proof-verifier", "vectors");
+const CLI = join(HERE, "..", "src", "cli.js");
+const bundle = JSON.parse(readFileSync(join(VECTORS, "valid-full.json"), "utf8"));
+const tampered = JSON.parse(readFileSync(join(VECTORS, "tampered-payload.json"), "utf8"));
 const protocol = JSON.parse(readFileSync(join(HERE, "..", "protocols", "agent-governance-baseline.json"), "utf8"));
 
 let failures = 0;
 const check = (cond, msg) => { if (cond) console.log(`  ok  ${msg}`); else { console.error(`  FAIL ${msg}`); failures++; } };
 
-// ---- A: a valid governed run qualifies ----
+// ---- Build a minimal signed full bundle from event specs ----
+const sha = (s) => createHash("sha256").update(s, "utf8").digest("hex");
+const GENESIS_PREFIX = "makerchecker-genesis:";
+function buildSignedBundle(specs) {
+  const instanceId = "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb";
+  const { privateKey, publicKey } = generateKeyPairSync("ed25519");
+  const publicKeyPem = publicKey.export({ type: "spki", format: "pem" }).toString();
+  const hashInput = (e) => ({ id: e.id, occurredAt: e.occurred_at, actor: e.actor, eventType: e.event_type, entityType: e.entity_type, entityId: e.entity_id, runId: e.run_id, payload: e.payload, prevHash: e.prev_hash });
+  let prev = sha(GENESIS_PREFIX + instanceId);
+  const events = specs.map((s, i) => {
+    const e = { seq: String(i + 1), id: `e${i + 1}`, occurred_at: `2026-01-01T00:00:0${i}.000Z`, actor: s.actor ?? { kind: "system" }, event_type: s.event_type, entity_type: null, entity_id: null, run_id: s.run_id ?? null, payload: s.payload ?? {}, prev_hash: prev };
+    e.hash = sha(canonicalJson(hashInput(e)));
+    prev = e.hash;
+    return e;
+  });
+  const unsigned = { bundleKind: "full", schemaVersion: 1, instanceId, exportedAt: "2026-01-01T01:00:00.000Z", runId: null, count: events.length, firstSeq: "1", lastSeq: String(events.length), headHash: events.at(-1).hash, eventHashesDigest: sha(events.map((e) => e.hash).join("\n")), publicKeyPem };
+  const signingString = canonicalJson({ bundleKind: unsigned.bundleKind, schemaVersion: unsigned.schemaVersion, instanceId, exportedAt: unsigned.exportedAt, runId: null, count: unsigned.count, firstSeq: unsigned.firstSeq, lastSeq: unsigned.lastSeq, headHash: unsigned.headHash, eventHashesDigest: unsigned.eventHashesDigest });
+  const signature = edSign(null, Buffer.from(signingString, "utf8"), privateKey).toString("base64");
+  return { manifest: { ...unsigned, signature }, events };
+}
+
+// ---- A: a valid governed run that never hits a limit does NOT qualify ----
+console.log("Test A — unexercised URS-004 fails closed:");
 const v = await generateValidation(bundle, protocol);
 const byId = Object.fromEntries(v.tests.map((t) => [t.id, t]));
 check(v.reliable, "chain verifies");
@@ -28,26 +60,80 @@ check(byId["OQ-001"].result === RESULT.PASS && byId["OQ-001"].citedSeqs.length >
 check(byId["OQ-002"].result === RESULT.PASS, "OQ-002 high-risk gate PASS");
 check(byId["PQ-001"].result === RESULT.PASS, "PQ-001 end-to-end run PASS");
 check(byId["OQ-004"].result === RESULT.NOT_APPLICABLE, "OQ-004 limits NOT_APPLICABLE (no limit hit in this run)");
-check(v.summary.FAIL === 0, "no test failed");
-check(v.qualified === true, "overall QUALIFIED");
-check(v.summary.requirementsCovered >= 4, `requirements covered (${v.summary.requirementsCovered}/${v.summary.requirementsTotal})`);
-
-// RTM coverage: URS-001 (deny-by-default) must be covered.
+check(v.summary.FAIL === 0, "no executed test failed");
 const rtmById = Object.fromEntries(v.rtm.map((r) => [r.urs, r]));
 check(rtmById["URS-001"].covered, "RTM: URS-001 covered");
 check(rtmById["URS-003"].covered, "RTM: URS-003 (audit trail) covered");
-
-// Report renders with the key sections.
-const md = renderReport(v, { generatedAt: "2026-06-29" });
-for (const section of ["Installation Qualification", "Operational Qualification", "Performance Qualification", "Requirements Traceability Matrix", "QUALIFIED"]) {
-  check(md.includes(section), `report contains "${section}"`);
+check(rtmById["URS-004"].untested && !rtmById["URS-004"].waived, "RTM: URS-004 not exercised and not waived");
+check(v.qualified === false, "untested URS-004 => NOT QUALIFIED (fail-closed)");
+const mdA = renderReport(v, { generatedAt: "2026-06-29" });
+check(mdA.includes("NOT QUALIFIED"), "report says NOT QUALIFIED");
+check(mdA.includes("**not exercised**"), "RTM flags the unexercised requirement");
+for (const section of ["Installation Qualification", "Operational Qualification", "Performance Qualification", "Requirements Traceability Matrix", "Deviations"]) {
+  check(mdA.includes(section), `report contains "${section}"`);
 }
 
+// ---- A2: the same run with an explicit waiver qualifies WITH a deviation ----
+console.log("Test A2 — waived URS-004 qualifies with a recorded deviation:");
+const REASON = "Fail-closed limits challenge scheduled for OQ round 2 (CAPA-114)";
+const w = await generateValidation(bundle, protocol, { waivers: [{ urs: "URS-004", reason: REASON }] });
+check(w.qualified === true, "waived URS-004 => QUALIFIED (with deviations)");
+check(w.summary.requirementsWaived === 1, "summary counts 1 waived requirement");
+const mdW = renderReport(w);
+check(mdW.includes("QUALIFIED (with deviations)"), "report says QUALIFIED (with deviations)");
+check(mdW.includes(REASON), "waiver reason recorded verbatim in the Deviations section");
+
+// ---- A3: a waiver cannot rescue a requirement whose tests executed and failed ----
+console.log("Test A3 — waiver never rescues a failed requirement:");
+const failingProtocol = {
+  ...protocol,
+  urs: [...protocol.urs, { id: "URS-099", text: "synthetic failing requirement", risk: "high" }],
+  fs: [...protocol.fs, { id: "FS-099", urs: ["URS-099"], text: "synthetic" }],
+  tests: [...protocol.tests, { id: "OQ-099", stage: "OQ", fs: ["FS-099"], title: "synthetic", procedure: "-", expected: "-", applicableWhen: "always", evidence: { eventType: "no.such.event" } }],
+};
+const f = await generateValidation(bundle, failingProtocol, { waivers: [{ urs: "URS-099", reason: "attempted waiver of a FAILED test" }, { urs: "URS-004", reason: REASON }] });
+check(f.qualified === false, "failed OQ-099 keeps the system NOT QUALIFIED despite the waiver");
+check(f.rtm.find((r) => r.urs === "URS-099").waived === false, "waiver not applied to an executed-and-failed requirement");
+
 // ---- B: a tampered bundle must NOT qualify ----
+console.log("Test B — tampered bundle:");
 const t = await generateValidation(tampered, protocol);
 check(t.reliable === false, "tampered chain does not verify");
 check(t.qualified === false, "tampered bundle NOT qualified");
 check(renderReport(t).includes("NOT QUALIFIED"), "tampered report says NOT QUALIFIED");
+
+// ---- C: a challenge run exercising every URS fully qualifies, no waivers ----
+console.log("Test C — challenge run exercises URS-004 and fully qualifies:");
+const challenge = buildSignedBundle([
+  { event_type: "audit.genesis", payload: { instanceId: "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb" } },
+  { event_type: "run.started", run_id: "r1", payload: { flow: "oq-challenge" } },
+  { event_type: "enforcement.blocked", run_id: "r1", payload: { code: "skill_not_granted", skill: "e2b-submit@1.0.0" } },
+  { event_type: "approval.requested", run_id: "r1", payload: { gate: "medical-review" } },
+  { event_type: "approval.decided", run_id: "r1", actor: { kind: "user", id: "user-0002" }, payload: { decision: "approved", decider: "user-0002", reason: "challenge approved" } },
+  { event_type: "enforcement.blocked", run_id: "r1", payload: { code: "limit_amount", limit: 1000, attempted: 5000 } },
+  { event_type: "skill.invoked", run_id: "r1", actor: { kind: "agent", id: "a1" }, payload: { skill: "lookup@1" } },
+  { event_type: "run.completed", run_id: "r1", payload: { status: "completed" } },
+]);
+const c = await generateValidation(challenge, protocol);
+const cById = Object.fromEntries(c.tests.map((x) => [x.id, x]));
+check(c.reliable, "challenge chain verifies");
+check(cById["OQ-004"].result === RESULT.PASS && cById["OQ-004"].citedSeqs.length > 0, "OQ-004 fail-closed limits PASS with cited evidence");
+check(c.rtm.every((r) => r.covered), "every URS covered (including URS-004)");
+check(c.qualified === true && c.summary.requirementsWaived === 0, "challenge run QUALIFIED with zero waivers");
+
+// ---- D: CLI exit codes are fail-closed ----
+console.log("Test D — CLI exit codes:");
+const run = (...args) => spawnSync(process.execPath, [CLI, "run", "--bundle", join(VECTORS, "valid-full.json"), "--protocol", "agent-governance-baseline", ...args], { encoding: "utf8" });
+const plain = run();
+check(plain.status === 1, `unwaived untested URS exits 1 (got ${plain.status})`);
+check(plain.stdout.includes("NOT QUALIFIED"), "CLI report says NOT QUALIFIED");
+const waived = run("--waive", "URS-004", "--reason", REASON);
+check(waived.status === 0, `waived run exits 0 (got ${waived.status})`);
+check(waived.stdout.includes("QUALIFIED (with deviations)") && waived.stdout.includes(REASON), "CLI report prints the deviation with its reason");
+const noReason = run("--waive", "URS-004");
+check(noReason.status === 2, `--waive without --reason is a usage error, exit 2 (got ${noReason.status})`);
+const badUrs = run("--waive", "URS-999", "--reason", "typo");
+check(badUrs.status === 2, `--waive of an unknown URS is an error, exit 2 (got ${badUrs.status})`);
 
 console.log(failures ? `\n${failures} check(s) FAILED` : "\nall checks passed");
 process.exit(failures ? 1 : 0);

--- a/packages/validation-kit/src/cli.js
+++ b/packages/validation-kit/src/cli.js
@@ -5,9 +5,12 @@
  *
  * Usage:
  *   mc-validate run --bundle <bundle.json> --protocol <id|path> [--key <pem>] [--out report.md] [--json]
+ *               [--waive URS-XXX --reason "..."]...
  *   mc-validate list-protocols
  *
- * Exit: 0 qualified; 1 not qualified or chain unverified; 2 usage error.
+ * Exit: 0 qualified (every requirement covered, or explicitly waived with a
+ * recorded reason); 1 not qualified (a failed test, an uncovered or
+ * unexercised requirement, or an unverified chain); 2 usage error.
  */
 
 import { readFileSync, readdirSync, writeFileSync } from "node:fs";
@@ -31,7 +34,12 @@ OPTIONS
   --key <pubkey.pem> pin the instance public key when verifying
   --out <file.md>    write the Markdown report to a file
   --json             print the machine-readable result instead of Markdown
-  -h, --help         show this help`;
+  --waive <URS-ID>   waive a requirement this bundle did not exercise (repeatable;
+                     each --waive requires a --reason, recorded as a deviation)
+  --reason <text>    written reason for the immediately preceding --waive
+  -h, --help         show this help
+
+A requirement the bundle never exercised fails closed (exit 1) unless waived.`;
 
 const listProtocols = () => readdirSync(PROTO_DIR).filter((f) => f.endsWith(".json")).map((f) => f.replace(/\.json$/, ""));
 
@@ -43,7 +51,7 @@ function resolveProtocol(idOrPath) {
 }
 
 function parse(argv) {
-  const o = { cmd: argv[0], bundle: null, protocol: null, key: null, out: null, json: false, help: false };
+  const o = { cmd: argv[0], bundle: null, protocol: null, key: null, out: null, json: false, help: false, waivers: [], parseError: null };
   for (let i = 1; i < argv.length; i++) {
     const a = argv[i];
     if (a === "-h" || a === "--help") o.help = true;
@@ -52,6 +60,16 @@ function parse(argv) {
     else if (a === "--protocol") o.protocol = argv[++i];
     else if (a === "--key") o.key = argv[++i];
     else if (a === "--out") o.out = argv[++i];
+    else if (a === "--waive") o.waivers.push({ urs: argv[++i], reason: null });
+    else if (a === "--reason") {
+      const last = o.waivers[o.waivers.length - 1];
+      if (!last || last.reason != null) o.parseError = "--reason must follow a --waive <URS-ID>";
+      else last.reason = argv[++i];
+    }
+  }
+  if (!o.parseError) {
+    const missing = o.waivers.find((w) => !w.urs || !w.reason || !w.reason.trim());
+    if (missing) o.parseError = `--waive ${missing.urs ?? "<URS-ID>"} requires a written --reason "..." (recorded as a deviation)`;
   }
   return o;
 }
@@ -61,6 +79,7 @@ async function main() {
   if (o.help || !o.cmd) { process.stdout.write(HELP + "\n"); process.exit(o.help ? 0 : 2); }
   if (o.cmd === "list-protocols") { process.stdout.write(listProtocols().join("\n") + "\n"); process.exit(0); }
   if (o.cmd !== "run") { process.stderr.write(`unknown command "${o.cmd}"\n`); process.exit(2); }
+  if (o.parseError) { process.stderr.write(`${o.parseError}\n`); process.exit(2); }
   if (!o.bundle || !o.protocol) { process.stderr.write("usage: mc-validate run --bundle <f> --protocol <id>\n"); process.exit(2); }
 
   let bundle;
@@ -70,7 +89,7 @@ async function main() {
   const protocol = resolveProtocol(o.protocol);
   if (!protocol) { process.stderr.write(`unknown protocol "${o.protocol}". Available: ${listProtocols().join(", ")}\n`); process.exit(2); }
 
-  const opts = {};
+  const opts = { waivers: o.waivers };
   if (o.key) { try { opts.expectedPublicKeyPem = readFileSync(o.key, "utf8"); } catch (e) { process.stderr.write(`cannot read key: ${e.message}\n`); process.exit(2); } }
 
   const result = await generateValidation(bundle, protocol, opts);
@@ -79,7 +98,8 @@ async function main() {
     process.stdout.write(JSON.stringify(result, null, 2) + "\n");
   } else {
     const md = renderReport(result);
-    if (o.out) { writeFileSync(o.out, md); process.stdout.write(`wrote ${o.out} — ${result.qualified ? "QUALIFIED" : "NOT QUALIFIED"}\n`); }
+    const verdict = result.qualified ? (result.summary.requirementsWaived ? "QUALIFIED (with deviations)" : "QUALIFIED") : "NOT QUALIFIED";
+    if (o.out) { writeFileSync(o.out, md); process.stdout.write(`wrote ${o.out} — ${verdict}\n`); }
     else process.stdout.write(md);
   }
 

--- a/packages/validation-kit/src/generate.js
+++ b/packages/validation-kit/src/generate.js
@@ -12,7 +12,27 @@ import { indexEvents, evalPredicate } from "../../obligations/src/predicates.js"
 
 export const RESULT = { PASS: "PASS", FAIL: "FAIL", NOT_APPLICABLE: "NOT_APPLICABLE" };
 
+/**
+ * Waivers are the only path past an unexercised requirement, and each one must
+ * name a protocol URS and carry a written reason — recorded in the report as a
+ * deviation. Anything malformed throws: qualification is fail-closed.
+ */
+function normalizeWaivers(waivers, protocol) {
+  if (waivers == null) return [];
+  if (!Array.isArray(waivers)) throw new Error("opts.waivers must be an array of { urs, reason }");
+  const known = new Set(protocol.urs.map((u) => u.id));
+  return waivers.map((w) => {
+    const urs = typeof w?.urs === "string" ? w.urs.trim() : "";
+    const reason = typeof w?.reason === "string" ? w.reason.trim() : "";
+    if (!urs || !reason) throw new Error(`waiver ${JSON.stringify(w)} must carry both a urs id and a written reason`);
+    if (!known.has(urs)) throw new Error(`waiver names unknown requirement "${urs}"; protocol defines: ${[...known].join(", ")}`);
+    return { urs, reason };
+  });
+}
+
 export async function generateValidation(bundle, protocol, opts = {}) {
+  const waivers = normalizeWaivers(opts.waivers, protocol);
+  const waiverByUrs = new Map(waivers.map((w) => [w.urs, w]));
   const chain = await verifyBundle(bundle, nodeCrypto, opts);
   const idx = indexEvents(Array.isArray(bundle?.events) ? bundle.events : []);
   const ctx = { chainVerified: chain.ok };
@@ -40,6 +60,10 @@ export async function generateValidation(bundle, protocol, opts = {}) {
     const testItems = tests.filter((t) => t.fs.some((fid) => fsById[fid]?.urs.includes(u.id)));
     const executed = testItems.filter((t) => t.result !== RESULT.NOT_APPLICABLE);
     const covered = executed.length > 0 && executed.every((t) => t.result === RESULT.PASS);
+    const untested = executed.length === 0;
+    // A waiver only excuses a requirement the run never exercised; it can never
+    // rescue a requirement whose tests executed and failed.
+    const waiver = untested ? waiverByUrs.get(u.id) ?? null : null;
     return {
       urs: u.id,
       ursText: u.text,
@@ -47,7 +71,9 @@ export async function generateValidation(bundle, protocol, opts = {}) {
       fs: fsItems.map((f) => f.id),
       tests: testItems.map((t) => ({ id: t.id, result: t.result })),
       covered,
-      untested: executed.length === 0,
+      untested,
+      waived: waiver != null,
+      waiverReason: waiver ? waiver.reason : null,
     };
   });
 
@@ -57,8 +83,11 @@ export async function generateValidation(bundle, protocol, opts = {}) {
   const summary = { total: tests.length, PASS: 0, FAIL: 0, NOT_APPLICABLE: 0 };
   for (const t of tests) summary[t.result] += 1;
   const requirementsCovered = rtm.filter((r) => r.covered).length;
+  const requirementsWaived = rtm.filter((r) => r.waived).length;
 
-  const qualified = chain.ok && summary.FAIL === 0 && rtm.every((r) => r.covered || r.untested);
+  // Fail-closed: a requirement the run never exercised does NOT qualify unless
+  // it was explicitly waived (a recorded deviation with a written reason).
+  const qualified = chain.ok && summary.FAIL === 0 && rtm.every((r) => r.covered || (r.untested && r.waived));
 
   return {
     protocol: { id: protocol.id, title: protocol.title, version: protocol.version },
@@ -68,7 +97,8 @@ export async function generateValidation(bundle, protocol, opts = {}) {
     stages,
     tests,
     rtm,
-    summary: { ...summary, requirementsCovered, requirementsTotal: protocol.urs.length },
+    waivers: waivers.map((w) => ({ ...w, applied: rtm.some((r) => r.urs === w.urs && r.waived) })),
+    summary: { ...summary, requirementsCovered, requirementsWaived, requirementsTotal: protocol.urs.length },
     meta: { ursById, fsById, testById },
   };
 }

--- a/packages/validation-kit/src/report.js
+++ b/packages/validation-kit/src/report.js
@@ -1,7 +1,8 @@
 /**
  * Renders a human-readable Computer System Validation report (Markdown) from a
  * generateValidation() result: chain statement, IQ/OQ/PQ result tables, the
- * Requirements Traceability Matrix, a qualification statement, and an approval
+ * Requirements Traceability Matrix, a deviations section (waived requirements
+ * with their recorded reasons), a qualification statement, and an approval
  * block for the operator's named reviewers to sign.
  */
 
@@ -32,14 +33,25 @@ export function renderReport(v, { generatedAt } = {}) {
     r.ursText,
     r.fs.join(", ") || "—",
     r.tests.map((t) => `${t.id} (${MARK[t.result]})`).join("<br>") || "—",
-    r.untested ? "not exercised" : r.covered ? "covered" : "**gap**",
+    r.covered ? "covered" : r.waived ? "not exercised — waived (deviation)" : r.untested ? "**not exercised**" : "**gap**",
   ]);
+
+  const deviations = v.rtm.filter((r) => r.waived);
+  const deviationSection = deviations.length
+    ? `The requirements below were **not exercised** by this run and were explicitly
+waived by the operator. Each waiver is a deviation: the reason is recorded here
+verbatim and is accepted (or rejected) by the named reviewers in the approval block.
+
+${table(["URS", "Requirement", "Waiver reason (deviation)"], deviations.map((r) => [r.urs, r.ursText, r.waiverReason]))}`
+    : "_None — every user requirement was exercised by this run._";
 
   const qualStatement = !v.chain.verified
     ? "**NOT QUALIFIED** — the audit chain did not verify; this report cannot be relied upon as validation evidence."
     : v.qualified
-      ? "**QUALIFIED** — every executed test passed and every user requirement exercised by this run is covered, on a verified chain."
-      : "**NOT QUALIFIED** — one or more executed tests failed or a user requirement is uncovered; see the matrix below.";
+      ? deviations.length
+        ? "**QUALIFIED (with deviations)** — every executed test passed and every user requirement is covered or explicitly waived, on a verified chain; see the Deviations section."
+        : "**QUALIFIED** — every executed test passed and every user requirement is covered, on a verified chain."
+      : "**NOT QUALIFIED** — one or more executed tests failed, or a user requirement is uncovered or was not exercised (and not waived); see the matrix below.";
 
   return `# Validation Report — ${v.protocol.title}
 
@@ -70,13 +82,17 @@ ${stageTable(v.stages.PQ)}
 
 ${table(["URS", "Requirement", "FS", "Tests", "Coverage"], rtmRows)}
 
-## 5. Summary
+## 5. Deviations
+
+${deviationSection}
+
+## 6. Summary
 
 - Test cases: **${v.summary.total}** — ${v.summary.PASS} passed, ${v.summary.FAIL} failed, ${v.summary.NOT_APPLICABLE} not applicable.
-- User requirements covered: **${v.summary.requirementsCovered} / ${v.summary.requirementsTotal}**.
+- User requirements covered: **${v.summary.requirementsCovered} / ${v.summary.requirementsTotal}**${v.summary.requirementsWaived ? ` (${v.summary.requirementsWaived} waived as deviation${v.summary.requirementsWaived === 1 ? "" : "s"})` : ""}.
 - Qualification outcome: ${qualStatement}
 
-## 6. Approval
+## 7. Approval
 
 The named reviewers below confirm the scope of this validation and accept the
 results. (Maker-checker applies to the validation itself: the author and the


### PR DESCRIPTION
Stacked on #65 (base: `feat/proof-verifier`). Fixes two confirmed integrity problems in the new OSS packages.

## What changed

### `packages/validation-kit` — qualification is now fail-closed
**Audit finding:** the verdict was `qualified = chain.ok && FAIL===0 && rtm.every(r => r.covered || r.untested)`, so an **untested** requirement passed silently: URS-004 (fail-closed limits) showed "not exercised" in the RTM while the banner said **QUALIFIED** and the CLI exited 0 — contradicting the README's own exit-code documentation (exit 1 for an uncovered requirement).

- Any unexercised URS now yields **NOT QUALIFIED** / exit 1, unless explicitly waived with `--waive URS-XXX --reason "..."` (each `--waive` requires a written reason; unknown URS or missing reason is a usage error, exit 2).
- Waivers are recorded verbatim in a new **Deviations** report section for the named reviewers to accept or reject, and the outcome reads **QUALIFIED (with deviations)**. A waiver never rescues a requirement whose tests executed and failed.
- README exit-code documentation aligned, and the shipped example is now honest and runnable: it shows that a bundle that never hit a limit fails closed on URS-004 and demonstrates both remedies — capture challenge-run evidence, or record the explicit waiver.

### `packages/obligations` — output carries its own caveats
**Audit finding:** the CLI printed "MET" without the profile's Partial caveats, and the Annex 11 profile misstated clause 12.4.

- Text output now prints each clause's `note` under its result (Partial caveats included) and a scope footer: `Scope: this profile assesses 5 of 6 mapped clauses in full; 1 is in part the operator's process, not evidenced by this tool.` plus a line that unmapped clauses are not assessed. Partial clauses are flagged explicitly (`"partial": true`) in the profiles.
- Annex 11 clause 12.4 no longer appends "segregation of duties" (12.4 is about recording operator identity): the title now carries the regulation text verbatim ("Management systems for data and for documents should be designed to record the identity of operators entering, changing, confirming or deleting data including date and time") and the product mapping moved to the note, which states that SoD is a separate control.
- Part 11 §11.50 tightened: `approval.decided` payloads in the vectors do carry `decider`/`decision` fields, but equality-only `payloadMatch` cannot express "field present" without pinning specific values (and matching `decision: "approved"` would wrongly exclude denials). Added a minimal `payloadHas` field-presence matcher to the predicate engine instead; 11.50 is now MET only when the decision event actually names the decider and the decision.

## How it was verified

Both zero-dependency suites run directly with node and pass:

- `node packages/validation-kit/scripts/test.mjs` → `all checks passed` (exit 0). New tests: unwaived untested URS-004 → NOT QUALIFIED and CLI exit 1; waived run → exit 0 with the deviation reason printed verbatim; a waiver cannot rescue an executed-and-failed test; a signed challenge run that exercises URS-004 (over-limit refusal) fully qualifies with zero waivers; `--waive` without `--reason` and unknown-URS waivers exit 2.
- `node packages/obligations/scripts/test.mjs` → `all checks passed` (exit 0). New tests: 11.50 NOT_EVIDENCED when `approval.decided` lacks decider/decision; CLI prints per-clause notes, the scope footer, and the verbatim 12.4 title.
- `node packages/proof-verifier/scripts/test.mjs` → `10/10 conformance cases passed` (shared predicate/verifier dependency unaffected; regenerated vectors restored so this PR carries no vector churn).

🤖 Generated with [Claude Code](https://claude.com/claude-code)