### PR TITLE
Make the repo front door healthcare-first

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,17 @@ MakerChecker is self-hosted software that governs AI agents through **structural
 
 Your agents keep running in their existing framework. MakerChecker is the checkpoint in front of them and the record behind them: a Fastify server on Postgres. Agents connect as a **flow** (MakerChecker runs the steps and gates) or a **proxy session** (MakerChecker authorizes and records tool calls your framework executes). Both write the same audit chain.
 
+## Built for regulated healthcare
+
+MakerChecker is built for healthcare and life-sciences workflows where regulation requires a named human to own the consequential act — and where "the AI did it" is never an answer an inspector accepts. Four governed use cases ship as runnable examples:
+
+- **Pharmacovigilance ICSR triage** — an agent triages the day's adverse-event cases, but a named medical reviewer signs before the binding seriousness determination starts the 15-day expedited clock (21 CFR 314.80) and the E2B(R3) report transmits. [examples/pv-icsr-processing](examples/pv-icsr-processing/README.md)
+- **MDR complaint reportability** — an agent triages device complaints, but the regulatory officer decides reportability behind a gate; only then are the MDR report skeletons drafted against the 21 CFR 803 clocks. [examples/mdr-reportability-triage](examples/mdr-reportability-triage/README.md)
+- **Oncology patient access** — a hub-services agent verifies benefits, matches funding, and drafts appeals on its own, but cannot submit an appeal or enroll a patient into copay/foundation support (Anti-Kickback / False Claims exposure) without a named access specialist signing. [examples/oncology-patient-access](examples/oncology-patient-access/README.md)
+- **CRO cohort identification** — a screening agent pre-screens trial candidates against inclusion/exclusion criteria, but the eligibility attestation that advances a patient is reserved for the investigator (ICH-GCP). [examples/cro-cohort-identification](examples/cro-cohort-identification/README.md)
+
+The controls themselves are domain-agnostic — the same engine that parks an ICSR at a medical-review gate also governs money movement. The finance demos ([daily cash reconciliation](examples/daily-cash-reconciliation/README.md), [AML alert triage](examples/aml-alert-triage/README.md)) stay in the repo as proof of that generality.
+
 **New here?** Operator → [Quickstart](#quickstart). Integrator → [Integration](#integration). Security reviewer → [docs/security-model.md](docs/security-model.md). Examiner → [docs/audit-spec.md](docs/audit-spec.md). GRC analyst → [docs/compliance/control-mapping.md](docs/compliance/control-mapping.md).
 
 [Live demo](https://makerchecker.ai/demo/): an agent is blocked from exceeding its grant and from approving its own work, the run's audit chain verifies offline, and a named human signs off only where a rule requires it. No signup.
@@ -39,27 +50,41 @@ Every refusal is named and audited:
 docker compose up
 ```
 
-Postgres and the server come up on port 3000. First boot seeds the demo and prints an admin key and an officer key — copy them from the logs.
+Postgres and the server come up on port 3000. First boot seeds the demos and prints two keys, each shown once — copy both from the logs. The **admin key** triggers runs; the **officer key** belongs to a second seeded user and is the eligible approver for identity-mode (`forbid_requester`) gates, where whoever triggered the run is refused as its approver.
 
 On a production (non-demo) deployment nothing is seeded; mint the first admin and its API key explicitly with `node dist/cli.js bootstrap-admin --email <e> --name <n>` (printed once). See [First admin on a fresh deployment](docs/quickstart.md#first-admin-on-a-fresh-deployment).
 
-A cash-reconciliation flow with a maker-checker constraint is seeded and ready:
+The drug-safety flow is seeded and ready: a pharmacovigilance case processor triages the day's adverse-event cases (two planted 15-day expedited cases among ten) and the run parks at the medical-review gate — the binding seriousness determination that starts the 15-day expedited clock (21 CFR 314.80) and the E2B(R3) transmission are high-risk skills the flow grammar refuses to run without that preceding gate:
 
 ```bash
-export H='authorization: Bearer mk_...'   # admin key from the logs
+export H='authorization: Bearer mk_...'         # DEMO ADMIN API KEY (triggers the run)
+export OFFICER='authorization: Bearer mk_...'   # DEMO OFFICER API KEY (decides the gate)
 
 # Trigger the flow
-curl -X POST localhost:3000/api/flows/daily-cash-reconciliation/runs -H "$H" -H 'content-type: application/json' -d '{}'
+curl -X POST localhost:3000/api/flows/pv-icsr-processing/runs -H "$H" -H 'content-type: application/json' -d '{}'
 
-# Inspect the pending approval gate
+# Inspect the pending medical-review gate
 curl localhost:3000/api/approvals -H "$H"
 
-# Approve the gate
+# The requester cannot approve their own run — this is refused with a 403
 curl -X POST localhost:3000/api/approvals/<id>/decision -H "$H" -H 'content-type: application/json' \
-  -d '{"decision":"approved","reason":"Exceptions resolved"}'
+  -d '{"decision":"approved","reason":"self-approval attempt"}'
+
+# The medical reviewer signs; only now does the clock start and the report file
+curl -X POST localhost:3000/api/approvals/<id>/decision -H "$OFFICER" -H 'content-type: application/json' \
+  -d '{"decision":"approved","reason":"Seriousness and expectedness confirmed for P-4003 and P-4009; file 15-day expedited ICSRs per 21 CFR 314.80"}'
 
 # Verify the audit chain
 curl localhost:3000/api/audit/verify -H "$H"
+```
+
+The planted cases and the deliberate near-misses are described in [examples/pv-icsr-processing](examples/pv-icsr-processing/README.md). The same engine governs money movement — the seeded [daily-cash-reconciliation](examples/daily-cash-reconciliation/README.md) flow parks at an exception-review gate the same way:
+
+```bash
+curl -X POST localhost:3000/api/flows/daily-cash-reconciliation/runs -H "$H" -H 'content-type: application/json' -d '{}'
+curl localhost:3000/api/approvals -H "$H"
+curl -X POST localhost:3000/api/approvals/<id>/decision -H "$H" -H 'content-type: application/json' \
+  -d '{"decision":"approved","reason":"Both exceptions explained"}'
 ```
 
 Full local setup, and running with real models, is in [docs/quickstart.md](docs/quickstart.md).

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -19,25 +19,31 @@ This starts `postgres:17-alpine` and builds/starts the server. The compose file 
 makerchecker server listening on :3000 (executor: scripted)
 ```
 
-Copy both keys; each is shown once (only the hashes are stored). The admin key triggers runs and approves the cash-reconciliation gate below; the officer key is the eligible approver for the AML flow's identity-mode gate. The requester cannot approve their own run. The web UI is served at `http://localhost:3000`.
+Copy both keys; each is shown once (only the hashes are stored). The admin key triggers runs; the officer key belongs to a second seeded user and is the eligible approver for identity-mode (`forbid_requester`) gates — the medical-review gate in `pv-icsr-processing` and the reportability gate in `mdr-reportability-triage`. The requester cannot approve their own run, so the user who triggered gets a 403 deciding those gates. The web UI is served at `http://localhost:3000`.
 
 `executor: scripted` means no model API key was found, so agent steps execute deterministically (fully air-gapped). Set `GEMINI_API_KEY` or `ANTHROPIC_API_KEY` on the host before `docker compose up` to run agents on a real model (`executor: llm (...)`).
 
-Drive the demo:
+Drive the drug-safety demo — the case processor triages the day's adverse-event cases and the run parks at the medical-review gate, which the admin (as the requester) cannot decide:
 
 ```bash
-export H='authorization: Bearer mk_...'   # the key printed at boot
+export H='authorization: Bearer mk_...'         # DEMO ADMIN API KEY
+export OFFICER='authorization: Bearer mk_...'   # DEMO OFFICER API KEY
 
-curl -X POST localhost:3000/api/flows/daily-cash-reconciliation/runs \
+curl -X POST localhost:3000/api/flows/pv-icsr-processing/runs \
   -H "$H" -H 'content-type: application/json' -d '{}'
 # -> {"runId":"..."}
 
 curl localhost:3000/api/approvals -H "$H"
-# -> {"approvals":[{"id":"...","step_key":"exception_review",...}]}
+# -> {"approvals":[{"id":"...","step_key":"medical_review",...}]}
 
 curl -X POST localhost:3000/api/approvals/<id>/decision \
   -H "$H" -H 'content-type: application/json' \
-  -d '{"decision":"approved","reason":"Both exceptions explained"}'
+  -d '{"decision":"approved","reason":"self-approval attempt"}'
+# -> 403 {"error":"the user who triggered this run cannot decide gate \"medical_review\" (forbid_requester)"}
+
+curl -X POST localhost:3000/api/approvals/<id>/decision \
+  -H "$OFFICER" -H 'content-type: application/json' \
+  -d '{"decision":"approved","reason":"Seriousness and expectedness confirmed for P-4003 and P-4009; file 15-day expedited ICSRs per 21 CFR 314.80"}'
 # -> {"ok":true}
 
 curl localhost:3000/api/runs/<runId> -H "$H"     # steps, approvals, audit events
@@ -45,7 +51,7 @@ curl localhost:3000/api/audit/verify -H "$H"
 # -> {"ok":true,"count":<n>,"headHash":"..."}
 ```
 
-The demo data contains exactly two planted exceptions (`T-1009` amount mismatch, `T-1012` missing ledger entry); see [the demo README](../examples/daily-cash-reconciliation/README.md), which also covers `self-approval-attempt`, the seeded flow that segregation of duties blocks. The seed also publishes `high-value-payment` (a 2-approver dual-authorization gate) and `aml-alert-triage`, the financial-crime demo that parks at a BSA-officer gate; see [its README](../examples/aml-alert-triage/README.md).
+The planted cases (`P-4003` acute liver failure, `P-4009` foreign-sourced anaphylaxis — both 15-day expedited) and the deliberate near-misses are in [the pv-icsr README](../examples/pv-icsr-processing/README.md). The seed also publishes `mdr-reportability-triage`, the medical-device demo that parks at a reportability gate for the regulatory officer ([README](../examples/mdr-reportability-triage/README.md)); `daily-cash-reconciliation`, with two planted exceptions (`T-1009` amount mismatch, `T-1012` missing ledger entry) and the `self-approval-attempt` flow that segregation of duties blocks ([README](../examples/daily-cash-reconciliation/README.md)); and `high-value-payment` (a 2-approver dual-authorization gate).
 
 ## Local development
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -68,6 +68,18 @@ await governed.invoke({ statement: ["t1", "t2", "t3"] });
 
 See [`connectors/langchain/README.md`](connectors/langchain/README.md) for the walkthrough. The Claude Agent SDK wrapper (`governClaudeTool` from [`@makerchecker/connector-claude-agent`](../packages/connector-claude-agent)) is shown inline in [`middleware/README.md`](middleware/README.md).
 
+## Healthcare use-case demos (runnable)
+
+Two proxy-path demos for the healthcare use cases that have no seeded flow yet. Like the incident scenarios below, each `demo.mjs` configures its roles, skills, and grants, drives a governed agent through the proxy, shows the consequential act denied to the agent acting alone, then verifies the audit chain.
+
+- [`oncology-patient-access`](oncology-patient-access/) — Oncology patient access: the hub agent drafts benefits, funding stacks, and appeals; who signs the enrollment and the appeal
+- [`cro-cohort-identification`](cro-cohort-identification/) — CRO cohort identification: AI pre-screens against inclusion/exclusion criteria; the investigator signs the eligibility attestation
+
+```bash
+node examples/oncology-patient-access/demo.mjs      # server on :3000, auth disabled or admin key
+node examples/cro-cohort-identification/demo.mjs
+```
+
 ## Incident scenarios (runnable)
 
 Twenty real incidents where an AI or automated system took a consequential action it should not have. Each directory is a self-contained, runnable scenario: its `demo.mjs` configures the roles, skills, grants, and limits, drives a governed agent through the proxy, shows the control denying or gating the action, then verifies the audit chain. Each `README.md` keeps the incident's sources and the mapping.
@@ -93,7 +105,6 @@ node examples/knight-capital-440m-runaway-trading/demo.mjs   # server on :3000, 
 - [`mata-v-avianca-fabricated-citations-filed`](mata-v-avianca-fabricated-citations-filed/) — Mata v Avianca: a hallucinated brief reached a federal court
 - [`meta-rogue-agent-sev1-data-exposure`](meta-rogue-agent-sev1-data-exposure/) — Meta Sev 1: an agent skipped the approval it was supposed to wait for
 - [`mypillow-ai-brief-fake-citations-repeat`](mypillow-ai-brief-fake-citations-repeat/) — The MyPillow brief: 30 fake AI citations, then a repeat offense
-- [`oncology-patient-access`](oncology-patient-access/) — Oncology patient access: who signs the enrollment and the appeal
 - [`replit-agent-deleted-production-database`](replit-agent-deleted-production-database/) — Replit agent deleted a production database during a code freeze
 - [`shadowleak-chatgpt-deep-research-gmail-exfiltration`](shadowleak-chatgpt-deep-research-gmail-exfiltration/) — ShadowLeak: zero-click Gmail exfiltration via the ChatGPT Deep Research agent
 - [`unitedhealth-nhpredict-ai-medicare-denials`](unitedhealth-nhpredict-ai-medicare-denials/) — nH Predict: an algorithm denying Medicare care with a 90% reversal rate

--- a/examples/README.md
+++ b/examples/README.md
@@ -93,6 +93,7 @@ node examples/knight-capital-440m-runaway-trading/demo.mjs   # server on :3000, 
 - [`mata-v-avianca-fabricated-citations-filed`](mata-v-avianca-fabricated-citations-filed/) — Mata v Avianca: a hallucinated brief reached a federal court
 - [`meta-rogue-agent-sev1-data-exposure`](meta-rogue-agent-sev1-data-exposure/) — Meta Sev 1: an agent skipped the approval it was supposed to wait for
 - [`mypillow-ai-brief-fake-citations-repeat`](mypillow-ai-brief-fake-citations-repeat/) — The MyPillow brief: 30 fake AI citations, then a repeat offense
+- [`oncology-patient-access`](oncology-patient-access/) — Oncology patient access: who signs the enrollment and the appeal
 - [`replit-agent-deleted-production-database`](replit-agent-deleted-production-database/) — Replit agent deleted a production database during a code freeze
 - [`shadowleak-chatgpt-deep-research-gmail-exfiltration`](shadowleak-chatgpt-deep-research-gmail-exfiltration/) — ShadowLeak: zero-click Gmail exfiltration via the ChatGPT Deep Research agent
 - [`unitedhealth-nhpredict-ai-medicare-denials`](unitedhealth-nhpredict-ai-medicare-denials/) — nH Predict: an algorithm denying Medicare care with a 90% reversal rate

--- a/examples/cro-cohort-identification/README.md
+++ b/examples/cro-cohort-identification/README.md
@@ -1,0 +1,143 @@
+# CRO Cohort Identification — AI Pre-Screens, the Investigator Signs
+
+CRO feasibility and clinical-operations teams pre-screen oncology populations
+against tight inclusion/exclusion criteria — line of therapy, biomarker /
+mutation status, ECOG performance status, prior treatments, washout period,
+disease progression. The criteria live in unstructured notes and the volume is
+high, so pre-screening is the obvious place to put an agent. But the act that
+matters is not the screening; it is the **eligibility determination** that
+advances a patient toward enrollment. Under ICH E6(R2/R3) Good Clinical
+Practice, the investigator is responsible for confirming each subject meets the
+protocol's eligibility criteria. A wrong inclusion is a protocol deviation, a
+data-integrity and patient-safety finding, and a sponsor/inspection liability.
+AI drafts the match; a named sub-investigator or principal investigator signs —
+this flow's architecture.
+
+## The safe / consequential asymmetry
+
+The cohort-screener agent does the high-volume, low-stakes work itself. It
+screens candidate records against the protocol I/E criteria (`cohort-screen`,
+low risk) and computes the matched/unmatched criteria per candidate with the
+supporting evidence (`criteria-match`, low risk). Both are reversible and
+advisory: surfacing a candidate carries no regulatory weight, so the agent never
+waits on a human to propose one.
+
+The act that *does* carry weight is gated. `eligibility-attest@1` attests that a
+candidate meets the inclusion/exclusion criteria and advances them to screening
+— the determination that, under ICH-GCP, is the investigator's to make and sign.
+It is published `risk_tier: high`.
+
+Two enforcement primitives close the gap, both checked at the proxy and failing
+closed:
+
+- **`skill_not_granted`** — the `cro-cohort-screener` role holds no attest
+  grant, so an attempt by the screener to attest eligibility is refused by
+  deny-by-default before it reaches a tool body. The agent cannot advance a
+  patient on its own.
+- **`high_risk_requires_gate`** — the `cro-sub-investigator` role holds the
+  attest grant but still cannot run a high-risk skill inline on the proxy. It
+  must run through a governed flow with a preceding approval gate. No path
+  advances a patient to screening without a named investigator passing the gate.
+
+## Separation of duties
+
+The control enforces **independent investigator review** — the ICH-GCP
+requirement that the investigator (or a qualified, delegated sub-investigator)
+confirm eligibility before a subject is enrolled. The screening agent that
+proposes a match may not be the party that attests it. The gate records, per
+determination, the investigator's identity and the evidence the eligibility call
+rests on, so an inclusion that later turns out to be a protocol deviation is
+attributable to a signed determination rather than to an opaque automated step.
+
+## The skills and their risk tiers
+
+| skill | risk | who holds it | what it does |
+| --- | --- | --- | --- |
+| `cohort-screen@1` | low | `cro-cohort-screener` | screen a record against the protocol I/E criteria; proposes only |
+| `criteria-match@1` | low | `cro-cohort-screener` | compute matched/unmatched criteria with supporting evidence |
+| `eligibility-attest@1` | **high** | `cro-sub-investigator` | attest the candidate meets I/E criteria and advance to screening |
+
+## The planted candidates
+
+Screening is rule-based against `trial_criteria.csv`: a candidate is a proposed
+match only if it clears every inclusion criterion (INC-1 NSCLC, INC-2 EGFR
+mutation, INC-3 ECOG ≤ 1, INC-4 washout ≥ 21 days, INC-5 confirmed RECIST
+progression) and trips no exclusion (EXC-1 more than two prior lines, EXC-2 ECOG
+≥ 3, EXC-3 washout < 21 days). `candidates.csv` plants ten records:
+
+- `PT-7001` (NSCLC, EGFR, ECOG 1, one prior line, 28-day washout, confirmed
+  progression): clears every inclusion and trips no exclusion — the fully
+  matched candidate.
+- `PT-7005` is the **borderline** case. It matches INC-1 through INC-4 cleanly,
+  but its progression note reads *"possible progression, repeat imaging
+  pending"* — not a confirmed RECIST 1.1 progression. INC-5 is therefore
+  **unresolved**, not failed. This is exactly the judgment call the agent must
+  route to the investigator rather than attest itself: an automated "include" on
+  an ambiguous note is the protocol deviation the control exists to prevent.
+
+The remaining rows are deliberate near-misses, each tripping one criterion but
+not the rest: `PT-7002` (KRAS, wrong biomarker → INC-2), `PT-7004` (three prior
+lines → EXC-1), `PT-7006` (14-day washout → EXC-3), `PT-7003` (ECOG 3 with two
+prior lines → INC-3 / EXC-2), `PT-7008` (stable disease, no progression →
+INC-5). `PT-7010` is a second ambiguous-progression record — borderline, not
+includable on the note alone.
+
+## Run it
+
+Boot the server (`docker compose up`, or locally with
+`MAKERCHECKER_AUTH_DISABLED=1`) and build the SDK (`corepack pnpm run build`),
+then:
+
+```bash
+node examples/cro-cohort-identification/demo.mjs
+```
+
+`MAKERCHECKER_URL` defaults to `http://localhost:3000`; set `MAKERCHECKER_API_KEY`
+to the admin key printed at first boot, or leave it unset against a no-auth local
+server.
+
+## What happens
+
+```
+proxy session 1f9c0b3a-7e21-4f5b-9a02-2d4e6c8a1b33 opened
+
+screener screens fully-matched candidate: {"candidate":"PT-7001","tumorType":"NSCLC","proposal":"all inclusion criteria met, no exclusion tripped"}
+screener matches criteria (PT-7001): {"candidate":"PT-7001","matched":["INC-1 tumor_type=NSCLC","INC-2 mutation=EGFR","INC-3 ecog<=1","INC-4 washout>=21d","EXC-1 prior_lines<=2 ok"],"unmatched":[],"evidence":"biomarker report EGFR exon 19 del; ECOG 1 per clinic note 2026-06-02; last therapy +28d"}
+screener screens borderline candidate: {"candidate":"PT-7005","tumorType":"NSCLC","proposal":"INC-5 unresolved — ambiguous progression note, route to investigator"}
+screener matches criteria (PT-7005): {"candidate":"PT-7005","matched":["INC-1 tumor_type=NSCLC","INC-2 mutation=EGFR","INC-3 ecog<=1","INC-4 washout>=21d"],"unmatched":["INC-5 confirmed_progression UNRESOLVED"],"evidence":"radiology note 2026-06-05: 'possible progression, repeat imaging pending' — not a confirmed RECIST progression"}
+screener eligibility attest DENIED (skill_not_granted): skill "cro-eligibility-attest@1" is not granted to the role of agent "cro-screener-bot"
+investigator inline attest DENIED (high_risk_requires_gate): skill "cro-eligibility-attest@1" is high-risk and cannot run through the proxy; run it in a governed flow with a preceding approval gate
+
+audit trail:
+  72  proxy.session.opened
+  73  proxy.check.allowed cro-screener-bot -> cro-cohort-screen@1
+  74  proxy.result.recorded  -> cro-cohort-screen@1
+  75  proxy.check.allowed cro-screener-bot -> cro-criteria-match@1
+  76  proxy.result.recorded  -> cro-criteria-match@1
+  77  proxy.check.allowed cro-screener-bot -> cro-cohort-screen@1
+  78  proxy.result.recorded  -> cro-cohort-screen@1
+  79  proxy.check.allowed cro-screener-bot -> cro-criteria-match@1
+  80  proxy.result.recorded  -> cro-criteria-match@1
+  81  enforcement.blocked cro-screener-bot -> cro-eligibility-attest@1 [skill_not_granted]
+  82  enforcement.blocked cro-investigator-bot -> cro-eligibility-attest@1 [high_risk_requires_gate]
+  83  proxy.session.closed
+
+audit chain: ok=true events=83
+```
+
+The screener screens both candidates and computes their criteria matches pre-gate
+because all of that work is reversible and granted. Its attempt to attest
+PT-7001 eligible is refused by deny-by-default, and even the granted
+sub-investigator cannot attest inline because the attest skill is high-risk.
+Every attempt — allowed, ungranted, and refused-high-risk — is written to the
+audit chain.
+
+## What this does not prevent
+
+It cannot judge whether an eligibility call is *correct*. An investigator can
+still sign an inclusion that turns out to be a protocol deviation, and a
+borderline progression note can still be read the wrong way. A gate the human
+ignores is not, by itself, a control. What changes is narrower: the
+determination becomes attributable. Every advance-to-screening carries a signed
+record of which investigator attested it and on what evidence, so a protocol
+deviation is traceable to a named sign-off rather than lost in an automated step.

--- a/examples/cro-cohort-identification/candidates.csv
+++ b/examples/cro-cohort-identification/candidates.csv
@@ -1,0 +1,11 @@
+patient_id,tumor_type,mutation_status,ecog,prior_lines,washout_days,progression_status
+PT-7001,NSCLC,EGFR,1,1,28,confirmed_progression
+PT-7002,NSCLC,KRAS,1,1,30,confirmed_progression
+PT-7003,NSCLC,EGFR,3,2,25,confirmed_progression
+PT-7004,NSCLC,EGFR,1,3,40,confirmed_progression
+PT-7005,NSCLC,EGFR,1,1,28,ambiguous_progression
+PT-7006,NSCLC,EGFR,0,2,14,confirmed_progression
+PT-7007,CRC,EGFR,1,1,35,confirmed_progression
+PT-7008,NSCLC,EGFR,2,0,45,stable_disease
+PT-7009,NSCLC,EGFR,1,2,22,confirmed_progression
+PT-7010,NSCLC,EGFR,1,1,60,ambiguous_progression

--- a/examples/cro-cohort-identification/demo.mjs
+++ b/examples/cro-cohort-identification/demo.mjs
@@ -1,0 +1,143 @@
+#!/usr/bin/env node
+// CRO cohort identification for oncology trials: a pre-screening agent reads a
+// candidate population against tight inclusion/exclusion criteria (line of
+// therapy, biomarker/mutation status, ECOG, prior treatments, washout, disease
+// progression) and proposes which records look eligible.
+//
+// The asymmetry: screening records and computing matched/unmatched criteria
+// with supporting evidence is reversible advisory work — granted to the
+// screening agent. Attesting that a patient MEETS the inclusion/exclusion
+// criteria is the eligibility determination that advances a human toward
+// enrollment; a wrong inclusion is a protocol deviation and an ICH-GCP
+// data-integrity and patient-safety finding. So eligibility-attest@1 is
+// published high-risk: the screener holds no grant for it (deny-by-default),
+// and even the sub-investigator/PI who does hold the grant cannot attest inline
+// on the proxy — it must run through a governed flow with a preceding approval
+// gate. AI drafts the match; a named investigator signs the determination.
+//
+// Run: boot the server (`docker compose up`, or locally with
+// MAKERCHECKER_AUTH_DISABLED=1), build the SDK, then:
+//   node examples/cro-cohort-identification/demo.mjs
+import {
+  connect,
+  ensureSkill,
+  ensureRole,
+  ensureAgent,
+  ensureGrant,
+  governedTool,
+  GovernanceDeniedError,
+  printTrailAndVerify,
+} from "../lib/scenario.mjs";
+
+const client = connect();
+
+// --- Configure MakerChecker for the scenario -------------------------------
+const screen = await ensureSkill(client, "cro-cohort-screen@1", {
+  description: "Screen candidate records against the protocol I/E criteria; proposes only",
+});
+const match = await ensureSkill(client, "cro-criteria-match@1", {
+  description: "Compute matched/unmatched criteria per candidate with the supporting evidence",
+});
+const attest = await ensureSkill(client, "cro-eligibility-attest@1", {
+  riskTier: "high",
+  description: "Attest a candidate meets I/E criteria and advance to screening (irreversible determination)",
+});
+
+// cohort-screener screens and matches criteria but holds NO attest grant.
+const screenerRole = await ensureRole(client, "cro-cohort-screener", {
+  description: "Screens candidates and computes criteria matches; cannot attest eligibility.",
+});
+// sub-investigator holds the attest grant, but the attest skill is high-risk,
+// so even a granted role cannot run it inline — it must pass an approval gate.
+const investigatorRole = await ensureRole(client, "cro-sub-investigator", {
+  description: "Attests eligibility only through a governed flow with an investigator sign-off gate.",
+});
+
+await ensureGrant(client, screenerRole, screen);
+await ensureGrant(client, screenerRole, match);
+await ensureGrant(client, investigatorRole, attest);
+
+await ensureAgent(client, "cro-screener-bot", "cro-cohort-screener");
+await ensureAgent(client, "cro-investigator-bot", "cro-sub-investigator");
+
+// --- Drive the governed agents through the proxy ---------------------------
+const { session } = await client.proxy.openSession({ label: "cro-cohort-identification" });
+console.log(`proxy session ${session.id} opened\n`);
+
+const screenCandidate = governedTool(client, session.id, "cro-screener-bot", "cro-cohort-screen@1", async (i) => ({
+  candidate: i.patientId,
+  tumorType: i.tumorType,
+  proposal: i.proposal,
+}));
+const matchCriteria = governedTool(client, session.id, "cro-screener-bot", "cro-criteria-match@1", async (i) => ({
+  candidate: i.patientId,
+  matched: i.matched,
+  unmatched: i.unmatched,
+  evidence: i.evidence,
+}));
+const screenerAttest = governedTool(client, session.id, "cro-screener-bot", "cro-eligibility-attest@1", async () => {
+  throw new Error("unreachable: deny-by-default blocks this");
+});
+const investigatorAttest = governedTool(client, session.id, "cro-investigator-bot", "cro-eligibility-attest@1", async () => {
+  throw new Error("unreachable: high-risk is refused on the proxy");
+});
+
+// 1. The screener screens a fully-matched candidate — allowed (it holds the
+//    screen grant). PT-7001: NSCLC, EGFR+, ECOG 1, one prior line, washout met,
+//    confirmed progression — clears every inclusion and trips no exclusion.
+console.log("screener screens fully-matched candidate:", JSON.stringify(await screenCandidate({
+  patientId: "PT-7001",
+  tumorType: "NSCLC",
+  proposal: "all inclusion criteria met, no exclusion tripped",
+})));
+
+// 2. The screener computes the criteria match with evidence — allowed
+//    (reversible, granted). Every I/E criterion resolves cleanly here.
+console.log("screener matches criteria (PT-7001):", JSON.stringify(await matchCriteria({
+  patientId: "PT-7001",
+  matched: ["INC-1 tumor_type=NSCLC", "INC-2 mutation=EGFR", "INC-3 ecog<=1", "INC-4 washout>=21d", "EXC-1 prior_lines<=2 ok"],
+  unmatched: [],
+  evidence: "biomarker report EGFR exon 19 del; ECOG 1 per clinic note 2026-06-02; last therapy +28d",
+})));
+
+// 3. The screener screens the borderline candidate — still allowed: screening
+//    and matching are advisory. PT-7005 trips INC-5 (confirmed progression):
+//    the progression note is ambiguous ("possible progression, repeat imaging
+//    pending"), so the match is flagged unresolved rather than asserted.
+console.log("screener screens borderline candidate:", JSON.stringify(await screenCandidate({
+  patientId: "PT-7005",
+  tumorType: "NSCLC",
+  proposal: "INC-5 unresolved — ambiguous progression note, route to investigator",
+})));
+
+console.log("screener matches criteria (PT-7005):", JSON.stringify(await matchCriteria({
+  patientId: "PT-7005",
+  matched: ["INC-1 tumor_type=NSCLC", "INC-2 mutation=EGFR", "INC-3 ecog<=1", "INC-4 washout>=21d"],
+  unmatched: ["INC-5 confirmed_progression UNRESOLVED"],
+  evidence: "radiology note 2026-06-05: 'possible progression, repeat imaging pending' — not a confirmed RECIST progression",
+})));
+
+// 4. The screener tries to attest PT-7001 eligible itself — denied by default;
+//    the screening role holds no attest grant, so the determination never
+//    reaches a tool body. The agent cannot advance a patient on its own.
+try {
+  await screenerAttest({ patientId: "PT-7001" });
+} catch (err) {
+  if (!(err instanceof GovernanceDeniedError)) throw err;
+  console.log(`screener eligibility attest DENIED (${err.code}): ${err.reason}`);
+}
+
+// 5. Even the granted sub-investigator cannot attest inline: the attest skill
+//    is high-risk, categorically refused on the proxy. The eligibility
+//    determination only proceeds through the governed flow, where it parks at
+//    the investigator sign-off gate. The borderline PT-7005 is exactly the
+//    record that must reach a human, not be auto-included.
+try {
+  await investigatorAttest({ patientId: "PT-7005" });
+} catch (err) {
+  if (!(err instanceof GovernanceDeniedError)) throw err;
+  console.log(`investigator inline attest DENIED (${err.code}): ${err.reason}`);
+}
+
+await client.proxy.closeSession(session.id);
+await printTrailAndVerify(client, session.id);

--- a/examples/cro-cohort-identification/trial_criteria.csv
+++ b/examples/cro-cohort-identification/trial_criteria.csv
@@ -1,0 +1,9 @@
+criterion_id,type,field,rule,description
+INC-1,inclusion,tumor_type,tumor_type==NSCLC,Histologically confirmed advanced non-small-cell lung cancer
+INC-2,inclusion,mutation_status,mutation_status==EGFR,Documented activating EGFR mutation by central biomarker testing
+INC-3,inclusion,ecog,ecog<=1,ECOG performance status 0 or 1 at screening
+INC-4,inclusion,washout_days,washout_days>=21,At least 21 days washout since last systemic anti-cancer therapy
+INC-5,inclusion,progression_status,progression_status==confirmed_progression,Radiographically confirmed RECIST 1.1 progression on prior line
+EXC-1,exclusion,prior_lines,prior_lines>2,More than two prior lines of systemic therapy excludes
+EXC-2,exclusion,ecog,ecog>=3,ECOG performance status 3 or worse excludes
+EXC-3,exclusion,washout_days,washout_days<21,Washout shorter than 21 days excludes

--- a/examples/mdr-reportability-triage/README.md
+++ b/examples/mdr-reportability-triage/README.md
@@ -40,11 +40,14 @@ likely to recur. The data plants two escalations among ten complaints:
 
 ```bash
 docker compose up   # from the repo root; seeds everything on first boot
-export H='authorization: Bearer mk_...'   # admin key printed at first boot
+# First boot prints two keys, each shown once: a DEMO ADMIN API KEY and a
+# DEMO OFFICER API KEY. The admin triggers the run; the officer decides the gate.
+export H='authorization: Bearer mk_...'         # DEMO ADMIN API KEY (triggers the run)
+export OFFICER='authorization: Bearer mk_...'   # DEMO OFFICER API KEY (approves the reportability gate)
 
 curl -X POST localhost:3000/api/flows/mdr-reportability-triage/runs -H "$H" -H 'content-type: application/json' -d '{}'
 curl localhost:3000/api/approvals -H "$H"
-curl -X POST localhost:3000/api/approvals/<id>/decision -H "$H" \
+curl -X POST localhost:3000/api/approvals/<id>/decision -H "$OFFICER" \
   -H 'content-type: application/json' -d '{"decision":"approved","reason":"C-3004 and C-3008 are reportable; file MDRs within their clocks"}'
 curl localhost:3000/api/runs/<runId> -H "$H"
 curl localhost:3000/api/audit/verify -H "$H"
@@ -52,8 +55,8 @@ curl localhost:3000/api/audit/verify -H "$H"
 
 The gate is identity-mode (`forbid_requester`): the user who triggered the run
 gets a 403 deciding it, and unauthenticated decisions are refused outright (fail
-closed). Approve with a key belonging to a different user than the one that
-triggered.
+closed). The DEMO OFFICER API KEY is the eligible approver, a different user
+than the one that triggered.
 
 Export the signed, offline-verifiable evidence bundle for inspection. An
 investigator verifies it with no access to your systems:

--- a/examples/oncology-patient-access/README.md
+++ b/examples/oncology-patient-access/README.md
@@ -1,0 +1,161 @@
+# Oncology Patient Access: Who Signs the Enrollment and the Appeal
+
+Specialty-pharmacy "hub" teams move patients onto $100k+/yr oncology therapies
+when coverage is thin. The work is bureaucratic and high-volume: benefits
+investigation, prior authorization, denials and appeals, and stitching funding
+across manufacturer copay cards and independent charitable foundations (PAN,
+HealthWell, LLS). An AI agent can do most of it. The two acts it must not do
+alone are the two that carry legal weight: **submitting** an appeal or prior-auth
+to the payer (an attestation of medical necessity) and **enrolling** a patient
+into a copay program or charitable foundation.
+
+The hazard is specific. Routing a government-insured patient — Medicare or
+Medicaid — into manufacturer copay support is Anti-Kickback Statute and False
+Claims Act exposure. An agent that auto-enrolls at scale turns a clerical
+shortcut into a federal liability, with no named human attesting that this
+patient, on this plan, was eligible for this program. So a named access
+specialist or pharmacist signs before any submit or enroll runs.
+
+## The risk
+
+The system that drafts an appeal and assembles a funding stack also files the
+appeal and enrolls the patient, with no named clinician attesting eligibility and
+no per-patient record of who approved which enrollment on what basis. Nothing
+separates proposing a funding stack from committing a patient into a program, and
+a wrong enrollment — a Medicare patient in a manufacturer copay card — stands as
+billed until someone catches it.
+
+## The mis-enrollment guardrail
+
+Even at the reversible proposal stage, the agent encodes the rule: manufacturer
+copay cards are barred for government plans. The `oncology-funding-match@1` skill
+routes a Medicare or Medicaid patient to an independent charitable foundation
+(PAN) and marks `copayCardEligible: false`; only a commercial patient gets a
+manufacturer copay card in the proposed stack. The demo runs the match for both a
+commercial patient (`PT-7001`, copay card permitted) and a Medicare patient
+(`PT-7004`, copay card excluded). The proposal is correct — but it is still only
+a proposal. Nothing is enrolled until the pharmacist signs.
+
+## The MakerChecker configuration
+
+The work splits by reversibility. Verifying benefits, matching a funding stack,
+and drafting a medical-necessity appeal are reversible: low-risk skills the
+`oncology-hub-access-coordinator` role holds and runs pre-gate. It holds **no
+submit or enroll grant**, so an attempt to file the appeal is refused by
+deny-by-default before it reaches a tool body.
+
+Submitting the appeal and enrolling the patient are irreversible, so
+`oncology-appeal-submit@1` and `oncology-foundation-enroll@1` are published at
+`riskTier: high` and refused on the proxy. They run only through a governed flow
+with a preceding approval gate, where a named access specialist / pharmacist
+signs each attestation before it executes. The
+`oncology-access-specialist-pharmacist` role holds both grants but cannot run
+either through the bare proxy.
+
+Two enforcement primitives close the gap, both checked at the proxy and failing
+closed:
+
+- **`skill_not_granted`** — the coordinator role holds no submit grant, so its
+  attempt to file the appeal is refused by deny-by-default before it reaches a
+  tool body.
+- **`high_risk_requires_gate`** — the access-specialist role holds the submit and
+  enroll grants but still cannot run a high-risk skill inline on the proxy. It
+  must run through a governed flow with a preceding approval gate. No path submits
+  an appeal or enrolls a patient without a named human signing.
+
+Skills:
+
+- `oncology-benefits-verify@1`, `riskTier: low` (run benefits verification and
+  identify the denial reason; commits nothing)
+- `oncology-funding-match@1`, `riskTier: low` (match an eligible funding stack to
+  the plan type; encodes the copay-card-for-government-plans guardrail)
+- `oncology-appeal-draft@1`, `riskTier: low` (draft the medical-necessity appeal
+  letter; commits nothing)
+- `oncology-appeal-submit@1`, `riskTier: high` (attest medical necessity and
+  submit the prior-auth / appeal to the payer; **not granted** to the
+  coordinator, and refused outside a gated flow)
+- `oncology-foundation-enroll@1`, `riskTier: high` (enroll the patient into a
+  copay program or charitable foundation; the AKS / FCA exposure point; refused
+  outside a gated flow)
+
+Roles and grants:
+
+- `oncology-hub-access-coordinator` — granted `oncology-benefits-verify@1`,
+  `oncology-funding-match@1`, `oncology-appeal-draft@1`. No submit/enroll grant.
+- `oncology-access-specialist-pharmacist` — granted `oncology-appeal-submit@1`
+  and `oncology-foundation-enroll@1`. The named signer, but only at a gate.
+
+## The mock data
+
+The demo logic runs on inline mock objects; the CSVs beside this README are
+illustrative data for the prose:
+
+- `denials.csv` — ten patient denials across commercial, medicare, medicaid, and
+  uninsured plan types (`patient_id, diagnosis, drug, plan_type, annual_cost_usd,
+  denial_reason`). `PT-7004` (melanoma, Opdivo, **medicare**) is the planted
+  case the guardrail must catch: it must never be auto-enrolled into manufacturer
+  copay support.
+- `funding_sources.csv` — copay cards and charitable foundations with open and
+  closed enrollment windows (`source, type, window_status, max_award_usd,
+  eligible_plan_types`). `manufacturer_copay` lists `commercial` only;
+  `lls_copay` and `good_days` are **closed** windows the match must skip.
+- `plan_criteria.csv` — the plan/appeal rules (`criterion_id, plan_type, field,
+  rule, description`), including `PC-002` / `PC-003`: manufacturer copay support
+  is **prohibited** for Medicare and Medicaid under the Anti-Kickback Statute.
+
+## Run it
+
+Boot the server (`docker compose up`, or locally with
+`MAKERCHECKER_AUTH_DISABLED=1`) and build the SDK (`corepack pnpm run build`),
+then:
+
+```bash
+node examples/oncology-patient-access/demo.mjs
+```
+
+## What happens
+
+```
+proxy session 3f9c1a20-7d44-4e1b-9c6a-2b8e51d0a7f3 opened
+
+coordinator verifies benefits: {"patient":"PT-7001","drug":"Keytruda","planType":"commercial","annualCostUsd":235200,"denialReason":"prior_authorization_required","coverage":"denied"}
+coordinator matches funding (commercial): {"patient":"PT-7001","planType":"commercial","proposedStack":["copay_card:manufacturer","charitable_foundation:HealthWell"],"copayCardEligible":true,"note":"commercial plan: copay card permitted"}
+coordinator matches funding (medicare): {"patient":"PT-7004","planType":"medicare","proposedStack":["charitable_foundation:PAN"],"copayCardEligible":false,"note":"government plan: manufacturer copay support EXCLUDED (AKS); route to independent foundation only"}
+coordinator drafts appeal: {"patient":"PT-7001","drug":"Keytruda","letter":"drafted","basis":"medical necessity per NCCN guideline; prior therapy failed"}
+coordinator submit DENIED (skill_not_granted): skill "oncology-appeal-submit@1" is not granted to the role of agent "oncology-hub-access-bot"
+specialist submit DENIED (high_risk_requires_gate): skill "oncology-appeal-submit@1" is high-risk and cannot run through the proxy; run it in a governed flow with a preceding approval gate
+specialist enroll DENIED (high_risk_requires_gate): skill "oncology-foundation-enroll@1" is high-risk and cannot run through the proxy; run it in a governed flow with a preceding approval gate
+
+audit trail:
+  412  proxy.session.opened
+  413  proxy.check.allowed oncology-hub-access-bot -> oncology-benefits-verify@1
+  414  proxy.result.recorded  -> oncology-benefits-verify@1
+  415  proxy.check.allowed oncology-hub-access-bot -> oncology-funding-match@1
+  416  proxy.result.recorded  -> oncology-funding-match@1
+  417  proxy.check.allowed oncology-hub-access-bot -> oncology-funding-match@1
+  418  proxy.result.recorded  -> oncology-funding-match@1
+  419  proxy.check.allowed oncology-hub-access-bot -> oncology-appeal-draft@1
+  420  proxy.result.recorded  -> oncology-appeal-draft@1
+  421  enforcement.blocked oncology-hub-access-bot -> oncology-appeal-submit@1 [skill_not_granted]
+  422  enforcement.blocked oncology-access-specialist-bot -> oncology-appeal-submit@1 [high_risk_requires_gate]
+  423  enforcement.blocked oncology-access-specialist-bot -> oncology-foundation-enroll@1 [high_risk_requires_gate]
+  424  proxy.session.closed
+
+audit chain: ok=true events=424
+```
+
+The coordinator verifies benefits, matches funding, and drafts the appeal
+pre-gate because all three skills are reversible and granted — and the Medicare
+patient is routed away from manufacturer copay support at the proposal stage. Its
+attempt to submit the appeal is refused by deny-by-default; the high-risk submit
+and enroll are refused on the proxy even for the access specialist that holds the
+grants. Every attempt — allowed, ungranted, and refused-high-risk — is written to
+the hash-chained, Ed25519-signed audit chain.
+
+## What this does not prevent
+
+It does not judge whether the appeal will win or whether the funding stack is the
+best one. A pharmacist who signs an enrollment the patient was not eligible for
+still creates the exposure. MakerChecker forces a named human to attest each
+submission and enrollment and records who approved it on what basis; it does not
+decide eligibility for them. Accountability, not adjudication.

--- a/examples/oncology-patient-access/demo.mjs
+++ b/examples/oncology-patient-access/demo.mjs
@@ -1,0 +1,187 @@
+#!/usr/bin/env node
+// Oncology patient access, funding & appeals: a specialty-pharmacy "hub" agent
+// works $100k+/yr oncology therapies for under-covered patients — benefits
+// investigation, denial reasons, funding stacks across manufacturer copay cards
+// and independent charitable foundations (PAN, HealthWell, LLS), and appeal
+// letters. All of that is reversible draft/assemble work the agent can do alone.
+//
+// Two acts carry real legal weight and are barred to the agent acting alone:
+// submitting the appeal/prior-auth to the payer (an attestation of medical
+// necessity / eligibility) and enrolling a patient into a copay program or
+// charitable foundation. Mis-enrollment — e.g. routing a Medicare patient into
+// manufacturer copay support — is Anti-Kickback Statute / False Claims Act
+// exposure, so a named access specialist or pharmacist must sign before submit
+// or enroll.
+//
+// The control that stops it: the coordinator role holds the low-risk draft
+// skills and NO submit/enroll grant (deny-by-default). The submit and enroll
+// skills are published high-risk, so even the access-specialist role that holds
+// them cannot run them through the bare proxy — they execute only in a governed
+// flow with a preceding approval gate where the pharmacist signs.
+//
+// Run: boot the server (`docker compose up`, or locally with
+// MAKERCHECKER_AUTH_DISABLED=1), build the SDK, then:
+//   node examples/oncology-patient-access/demo.mjs
+import {
+  connect,
+  ensureSkill,
+  ensureRole,
+  ensureAgent,
+  ensureGrant,
+  governedTool,
+  GovernanceDeniedError,
+  printTrailAndVerify,
+} from "../lib/scenario.mjs";
+
+const client = connect();
+
+// --- Configure MakerChecker for the scenario -------------------------------
+const benefitsVerify = await ensureSkill(client, "oncology-benefits-verify@1", {
+  description: "Run benefits verification and identify the denial reason; commits nothing",
+});
+const fundingMatch = await ensureSkill(client, "oncology-funding-match@1", {
+  description: "Match an eligible funding stack (copay card + charitable foundation) to the patient's plan type",
+});
+const appealDraft = await ensureSkill(client, "oncology-appeal-draft@1", {
+  description: "Draft a medical-necessity appeal letter for the payer; commits nothing",
+});
+// Submitting the appeal/prior-auth attests medical necessity to the payer; it is
+// consequential and irreversible: high risk tier, refused on the proxy.
+const appealSubmit = await ensureSkill(client, "oncology-appeal-submit@1", {
+  riskTier: "high",
+  description: "Attest medical necessity and SUBMIT the prior-auth / appeal to the payer (irreversible)",
+});
+// Enrolling a patient into a copay program / charitable foundation is the
+// Anti-Kickback / False Claims exposure point: high risk tier, refused on the
+// proxy. A named access specialist or pharmacist must sign before it runs.
+const foundationEnroll = await ensureSkill(client, "oncology-foundation-enroll@1", {
+  riskTier: "high",
+  description: "ENROLL the patient into a copay program or charitable foundation (irreversible; AKS/FCA exposure)",
+});
+
+// The hub coordinator can verify, match funding, and draft appeals, but holds NO
+// submit or enroll grant (deny by default) — it can propose, never commit.
+const coordinatorRole = await ensureRole(client, "oncology-hub-access-coordinator", {
+  description: "Verifies benefits, matches funding, drafts appeals; cannot submit or enroll a patient.",
+});
+// The access specialist / pharmacist holds the submit and enroll grants, but the
+// skills' high risk tier forces them through an approval gate before they run.
+const specialistRole = await ensureRole(client, "oncology-access-specialist-pharmacist", {
+  description: "Named signer for submit/enroll, but only through a gated flow.",
+});
+
+await ensureGrant(client, coordinatorRole, benefitsVerify);
+await ensureGrant(client, coordinatorRole, fundingMatch);
+await ensureGrant(client, coordinatorRole, appealDraft);
+await ensureGrant(client, specialistRole, appealSubmit);
+await ensureGrant(client, specialistRole, foundationEnroll);
+
+await ensureAgent(client, "oncology-hub-access-bot", "oncology-hub-access-coordinator");
+await ensureAgent(client, "oncology-access-specialist-bot", "oncology-access-specialist-pharmacist");
+
+// --- Drive the governed agents through the proxy ---------------------------
+const { session } = await client.proxy.openSession({ label: "oncology-patient-access-funding-appeal" });
+console.log(`proxy session ${session.id} opened\n`);
+
+const verifyBenefits = governedTool(client, session.id, "oncology-hub-access-bot", "oncology-benefits-verify@1", async (i) => ({
+  patient: i.patient,
+  drug: i.drug,
+  planType: i.planType,
+  annualCostUsd: i.annualCostUsd,
+  denialReason: i.denialReason,
+  coverage: "denied",
+}));
+const matchFunding = governedTool(client, session.id, "oncology-hub-access-bot", "oncology-funding-match@1", async (i) => {
+  // Mis-enrollment guardrail (proposal only): manufacturer copay cards are barred
+  // for government-insured patients (Medicare/Medicaid) under the Anti-Kickback
+  // Statute. The agent surfaces the correct stack but enrolls nothing.
+  const govPlan = i.planType === "medicare" || i.planType === "medicaid";
+  return {
+    patient: i.patient,
+    planType: i.planType,
+    proposedStack: govPlan
+      ? ["charitable_foundation:PAN"]
+      : ["copay_card:manufacturer", "charitable_foundation:HealthWell"],
+    copayCardEligible: !govPlan,
+    note: govPlan
+      ? "government plan: manufacturer copay support EXCLUDED (AKS); route to independent foundation only"
+      : "commercial plan: copay card permitted",
+  };
+});
+const draftAppeal = governedTool(client, session.id, "oncology-hub-access-bot", "oncology-appeal-draft@1", async (i) => ({
+  patient: i.patient,
+  drug: i.drug,
+  letter: "drafted",
+  basis: "medical necessity per NCCN guideline; prior therapy failed",
+}));
+const coordinatorSubmit = governedTool(client, session.id, "oncology-hub-access-bot", "oncology-appeal-submit@1", async () => {
+  throw new Error("unreachable: deny-by-default blocks this");
+});
+const specialistSubmit = governedTool(client, session.id, "oncology-access-specialist-bot", "oncology-appeal-submit@1", async () => {
+  throw new Error("unreachable: high-risk skill is refused on the proxy");
+});
+const specialistEnroll = governedTool(client, session.id, "oncology-access-specialist-bot", "oncology-foundation-enroll@1", async () => {
+  throw new Error("unreachable: high-risk skill is refused on the proxy");
+});
+
+// 1. The coordinator verifies benefits and identifies the denial reason — allowed.
+console.log("coordinator verifies benefits:", JSON.stringify(await verifyBenefits({
+  patient: "PT-7001",
+  drug: "Keytruda",
+  planType: "commercial",
+  annualCostUsd: 235200.0,
+  denialReason: "prior_authorization_required",
+})));
+
+// 2. The coordinator matches a funding stack — allowed. The Medicare patient is
+//    routed to an independent foundation, NOT manufacturer copay support: the
+//    mis-enrollment guardrail at the proposal stage.
+console.log("coordinator matches funding (commercial):", JSON.stringify(await matchFunding({
+  patient: "PT-7001",
+  planType: "commercial",
+})));
+console.log("coordinator matches funding (medicare):", JSON.stringify(await matchFunding({
+  patient: "PT-7004",
+  planType: "medicare",
+})));
+
+// 3. The coordinator drafts the medical-necessity appeal letter — allowed.
+console.log("coordinator drafts appeal:", JSON.stringify(await draftAppeal({
+  patient: "PT-7001",
+  drug: "Keytruda",
+})));
+
+// 4. The coordinator tries to SUBMIT the appeal to the payer — denied by default;
+//    it holds no submit grant, so the attestation never reaches a tool body. The
+//    drafting system cannot file its own appeal.
+try {
+  await coordinatorSubmit({ patient: "PT-7001", payer: "commercial-PBM" });
+} catch (err) {
+  if (!(err instanceof GovernanceDeniedError)) throw err;
+  console.log(`coordinator submit DENIED (${err.code}): ${err.reason}`);
+}
+
+// 5. Even the access specialist, who holds the submit grant, cannot submit
+//    through the proxy: the submit skill is high risk and must run through a
+//    governed flow with a preceding approval gate. A named pharmacist signs the
+//    medical-necessity attestation at the gate.
+try {
+  await specialistSubmit({ patient: "PT-7001", payer: "commercial-PBM" });
+} catch (err) {
+  if (!(err instanceof GovernanceDeniedError)) throw err;
+  console.log(`specialist submit DENIED (${err.code}): ${err.reason}`);
+}
+
+// 6. Enrolling the patient into a copay program / charitable foundation is the
+//    same way: high risk, refused inline even for the granted specialist. A
+//    named human must sign before any enrollment runs — the control that keeps a
+//    Medicare patient out of manufacturer copay support (AKS/FCA exposure).
+try {
+  await specialistEnroll({ patient: "PT-7004", planType: "medicare", program: "manufacturer-copay" });
+} catch (err) {
+  if (!(err instanceof GovernanceDeniedError)) throw err;
+  console.log(`specialist enroll DENIED (${err.code}): ${err.reason}`);
+}
+
+await client.proxy.closeSession(session.id);
+await printTrailAndVerify(client, session.id);

--- a/examples/oncology-patient-access/denials.csv
+++ b/examples/oncology-patient-access/denials.csv
@@ -1,0 +1,11 @@
+patient_id,diagnosis,drug,plan_type,annual_cost_usd,denial_reason
+PT-7001,nsclc,Keytruda,commercial,235200.00,prior_authorization_required
+PT-7002,multiple_myeloma,Darzalex,commercial,198400.00,step_therapy_not_met
+PT-7003,colorectal,Avastin,medicaid,112800.00,non_formulary
+PT-7004,melanoma,Opdivo,medicare,189600.00,prior_authorization_required
+PT-7005,breast,Enhertu,commercial,165000.00,site_of_care
+PT-7006,cml,Tasigna,uninsured,142000.00,no_coverage
+PT-7007,renal_cell,Cabometyx,medicare,228000.00,step_therapy_not_met
+PT-7008,lymphoma,Polivy,commercial,204500.00,prior_authorization_required
+PT-7009,ovarian,Lynparza,medicaid,131400.00,non_formulary
+PT-7010,prostate,Xtandi,uninsured,156800.00,no_coverage

--- a/examples/oncology-patient-access/funding_sources.csv
+++ b/examples/oncology-patient-access/funding_sources.csv
@@ -1,0 +1,9 @@
+source,type,window_status,max_award_usd,eligible_plan_types
+manufacturer_copay,copay_card,open,26000.00,commercial
+pan_foundation,charitable_foundation,open,15000.00,medicare;medicaid;commercial
+healthwell,charitable_foundation,open,12000.00,medicare;commercial
+lls_copay,charitable_foundation,closed,10000.00,medicare;medicaid;commercial;uninsured
+patient_advocate_fund,charitable_foundation,open,8000.00,uninsured;medicaid
+good_days,charitable_foundation,closed,7500.00,medicare;commercial
+manufacturer_pap,charitable_foundation,open,30000.00,uninsured
+cancercare_copay,charitable_foundation,open,9000.00,medicare;medicaid;commercial

--- a/examples/oncology-patient-access/plan_criteria.csv
+++ b/examples/oncology-patient-access/plan_criteria.csv
@@ -1,0 +1,9 @@
+criterion_id,plan_type,field,rule,description
+PC-001,commercial,copay_card,allowed,manufacturer copay cards permitted for commercially insured patients
+PC-002,medicare,copay_card,prohibited,manufacturer copay support barred for Medicare patients under the Anti-Kickback Statute
+PC-003,medicaid,copay_card,prohibited,manufacturer copay support barred for Medicaid patients under the Anti-Kickback Statute
+PC-004,uninsured,copay_card,not_applicable,uninsured patients route to manufacturer patient-assistance programs not copay cards
+PC-005,commercial,appeal,medical_necessity,first-level appeal requires NCCN-supported medical-necessity attestation
+PC-006,medicare,appeal,medical_necessity,Medicare redetermination requires documented prior-therapy failure
+PC-007,medicaid,appeal,prior_auth,state Medicaid prior-authorization with formulary-exception request
+PC-008,uninsured,appeal,not_applicable,no payer appeal; route to foundation and patient-assistance enrollment

--- a/examples/pv-icsr-processing/README.md
+++ b/examples/pv-icsr-processing/README.md
@@ -60,19 +60,23 @@ reviewer confirms at the gate.
 
 ```bash
 docker compose up   # from the repo root; seeds everything on first boot
-export H='authorization: Bearer mk_...'   # admin key printed at first boot
+# First boot prints two keys, each shown once: a DEMO ADMIN API KEY and a
+# DEMO OFFICER API KEY. The admin triggers the run; the officer decides the gate.
+export H='authorization: Bearer mk_...'         # DEMO ADMIN API KEY (triggers the run)
+export OFFICER='authorization: Bearer mk_...'   # DEMO OFFICER API KEY (approves the medical-review gate)
 
 curl -X POST localhost:3000/api/flows/pv-icsr-processing/runs -H "$H" -H 'content-type: application/json' -d '{}'
 curl localhost:3000/api/approvals -H "$H"
-curl -X POST localhost:3000/api/approvals/<id>/decision -H "$H" \
+curl -X POST localhost:3000/api/approvals/<id>/decision -H "$OFFICER" \
   -H 'content-type: application/json' -d '{"decision":"approved","reason":"Seriousness and expectedness confirmed for P-4003 and P-4009; file 15-day expedited ICSRs per 21 CFR 314.80"}'
 curl localhost:3000/api/runs/<runId> -H "$H"
 curl localhost:3000/api/audit/verify -H "$H"
 ```
 
-Try to approve with the **same** key that triggered the run: you get a 403. The
-binding seriousness call and the E2B(R3) submission only run after a *different*,
-authenticated medical reviewer signs off.
+Try to approve with the **same** key that triggered the run (`-H "$H"`): you get
+a 403 (`forbid_requester`). The binding seriousness call and the E2B(R3)
+submission only run after a *different*, authenticated medical reviewer — the
+DEMO OFFICER API KEY here — signs off.
 
 Export the signed, offline-verifiable evidence for the run — every agent action,
 the high-risk skills held behind the gate, grant state, and the reviewer's


### PR DESCRIPTION
## What changed

- **README**: new "Built for regulated healthcare" section near the top naming the four use cases — pharmacovigilance ICSR triage, MDR complaint reportability, oncology patient access, CRO cohort identification — one sentence each, linking their `examples/` dirs. The quickstart hero walkthrough is switched from `daily-cash-reconciliation` to `pv-icsr-processing` (the run parks at the `medical_review` gate before the binding seriousness call starts the 15-day expedited clock and the E2B(R3) filing transmits; the requester's own approval attempt is shown being refused with a 403). The finance demos are reframed under an explicit credibility line — the same engine governs money movement — instead of leading.
- **docs/quickstart.md**: the `aml-alert-triage` feature spot and the "BSA officer" framing are replaced with `pv-icsr-processing` (now the drive-the-demo block) and `mdr-reportability-triage`; the cash-reconciliation and `high-value-payment` demos remain listed after them.
- **Officer key documented** (audit finding: the officer/identity key for the healthcare flows was undocumented): both quickstarts and the pv/mdr example READMEs now name the DEMO OFFICER API KEY as the eligible approver for identity-mode (`forbid_requester`) gates. The pv/mdr "Run it" blocks previously approved with the requester's own key, which is refused with a 403 — they now export and use `$OFFICER`.
- **Cherry-picked `fb252c9`** from `pv-icsr-demos` (authored by @sammysltd): the `examples/oncology-patient-access/` and `examples/cro-cohort-identification/` runnable demos, so all four use-case links in the new README section resolve on `main`. `examples/README.md` lists them in their own use-case section (restoring the incident list to its stated twenty).
- `docker-compose.yml` / `DEMO_DATA_DIR` are untouched: the pv fixtures resolve as siblings of the seeded data dir, so the seeded compose demo and CI's compose boot test are unchanged.

## Why

The repo's front door had zero healthcare terms while the company sells only healthcare (audit finding): the README hero was daily-cash-reconciliation and docs/quickstart featured aml-alert-triage with a "BSA officer" — finance/AML positioning that was dropped. The healthcare flows are seeded and work, so they should lead, with the finance demos kept as proof the engine is domain-agnostic.

## How it was verified

Every command block added or edited was executed verbatim against `docker compose up -d --build` in this branch's worktree:

- README hero (pv): trigger returned `{"runId":...}`; the gate parked (`step_key":"medical_review"`); approving with the requester key returned **403** `{"error":"the user who triggered this run cannot decide gate \"medical_review\" (forbid_requester)"}`; approving with the officer key returned `{"ok":true}`; run completed; `GET /api/audit/verify` returned `{"ok":true,"count":157,"headHash":"e705570b..."}`. Run twice end to end.
- README money-movement block (recon): trigger, gate `exception_review`, approve with admin key `{"ok":true}`, run completed, audit `ok:true`.
- docs/quickstart drive block: same pv sequence as above, including the expected outputs shown in comments.
- mdr example block: gate `reportability_decision` parked, officer approve `{"ok":true}`, run completed, audit `ok:true`.
- Cherry-picked demos: `node examples/oncology-patient-access/demo.mjs` ended `audit chain: ok=true events=122`; `node examples/cro-cohort-identification/demo.mjs` ended `audit chain: ok=true events=144` (SDK compiled with standalone tsc; the demos and SDK are dependency-free).
- All relative links in the edited markdown files were checked to resolve; `curl -fsS http://localhost:3000/healthz` returns `{"status":"ok","schemaVersion":1}` (what CI's compose boot job asserts). The cherry-picked files are outside the pnpm workspace, so `pnpm run ci` scope is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)