### PR TITLE
Reject ill-formed Unicode (non-I-JSON) before hashing, fail closed

### DIFF
--- a/docs/audit-spec.md
+++ b/docs/audit-spec.md
@@ -12,6 +12,8 @@ All hashing and signing operates on **RFC 8785 (JSON Canonicalization Scheme)** 
 - Object keys sorted by UTF-16 code units (plain lexicographic sort of code units).
 - Numbers serialized per the ECMAScript `Number::toString` algorithm (what `JSON.stringify` produces). Non-finite numbers are invalid.
 - Object members with `undefined` values are omitted; `null` is serialized as `null`.
+- Input **must be I-JSON (RFC 7493)**: every string — object key or value — must be well-formed Unicode. An unpaired surrogate has no interoperable RFC 8785 serialization (RFC 8785 presumes I-JSON input; implementations disagree on ill-formed strings), so it is **rejected before hashing, fail closed**: the API refuses such a payload with HTTP 400, the serializer throws, and a conformant verifier rejects a bundle containing one as a *spec violation* (verdict `ill_formed_string`), distinct from tamper.
+- No Unicode normalization is applied anywhere: NFC and NFD forms of the same text are distinct strings and hash differently; characters outside JSON's mandatory escape set (including supplementary-plane characters such as U+1F600) are emitted literally, never as `\uXXXX` escapes.
 
 ## 2. Event hash
 
@@ -34,7 +36,7 @@ hash = SHA-256( canonicalJson({
 Notes:
 
 - Key names in the hashed object are exactly as above (camelCase). After canonical key sorting the serialized member order is: `actor`, `entityId`, `entityType`, `eventType`, `id`, `occurredAt`, `payload`, `prevHash`, `runId`.
-- `occurredAt` is stored in the database as **text** (ISO 8601 UTC, e.g. `2026-06-12T09:30:00.123Z`) and hashed byte-for-byte as stored. It is not a `timestamptz`: timestamp types reformat on round-trip, breaking exact recomputation. Fixed-format UTC ISO strings sort lexicographically in chronological order.
+- `occurredAt` is stored in the database as **text** in exactly the grammar `YYYY-MM-DDTHH:MM:SS.mmmZ` (RFC 3339 UTC with exactly three fractional-second digits and uppercase `T` and `Z`, i.e. the output of ECMAScript `Date.prototype.toISOString`, e.g. `2026-06-12T09:30:00.123Z`) and hashed byte-for-byte as stored. It is not a `timestamptz`: timestamp types reformat on round-trip, breaking exact recomputation. Fixed-format UTC ISO strings sort lexicographically in chronological order.
 - **`seq` is excluded from the hash.** `seq` is a database identity column that records only storage order; identity columns leave gaps when transactions abort, so `seq` values carry no integrity meaning. Chain order is defined solely by `prevHash` linkage. A verifier must not assume `seq` values are contiguous.
 
 ## 3. Genesis and chain rule

--- a/packages/server/src/app.test.ts
+++ b/packages/server/src/app.test.ts
@@ -218,6 +218,77 @@ describe("security hardening", () => {
     });
   });
 
+  describe("I-JSON ingress guard (well-formed Unicode, fail closed)", () => {
+    afterEach(() => {
+      delete process.env.MAKERCHECKER_AUTH_DISABLED;
+    });
+
+    it("rejects a lone surrogate in a run input with a 400 naming the JSON path", async () => {
+      process.env.MAKERCHECKER_AUTH_DISABLED = "1";
+      const app = await buildApp(stubCtx);
+      // Raw body: JSON.parse accepts the lone-surrogate escape, but such a
+      // string is not I-JSON and has no interoperable RFC 8785 serialization.
+      // It must be a clean 400 at ingress, not a 500 from the canonicalizer
+      // throwing deep inside the audit transaction.
+      const res = await app.inject({
+        method: "POST",
+        url: "/api/flows/recon/runs",
+        headers: { "content-type": "application/json" },
+        payload: '{"input":{"note":"\\ud800"}}',
+      });
+      expect(res.statusCode).toBe(400);
+      expect(res.json()).toEqual({
+        error: "payload contains ill-formed Unicode (unpaired surrogate) at $.input.note",
+      });
+      await app.close();
+    });
+
+    it("rejects a lone surrogate in an object KEY", async () => {
+      process.env.MAKERCHECKER_AUTH_DISABLED = "1";
+      const app = await buildApp(stubCtx);
+      const res = await app.inject({
+        method: "POST",
+        url: "/api/flows/recon/runs",
+        headers: { "content-type": "application/json" },
+        payload: '{"input":{"\\udc00key":1}}',
+      });
+      expect(res.statusCode).toBe(400);
+      expect(res.body).toContain("ill-formed Unicode (unpaired surrogate)");
+      await app.close();
+    });
+
+    it("rejects a lone surrogate in an approval decision reason", async () => {
+      process.env.MAKERCHECKER_AUTH_DISABLED = "1";
+      const app = await buildApp(stubCtx);
+      const res = await app.inject({
+        method: "POST",
+        url: "/api/approvals/11111111-1111-1111-1111-111111111111/decision",
+        headers: { "content-type": "application/json" },
+        payload: '{"decision":"approved","reason":"ok\\udfff"}',
+      });
+      expect(res.statusCode).toBe(400);
+      expect(res.json()).toEqual({
+        error: "payload contains ill-formed Unicode (unpaired surrogate) at $.reason",
+      });
+      await app.close();
+    });
+
+    it("is inert for well-formed Unicode (astral emoji, NFC/NFD pairs)", async () => {
+      process.env.MAKERCHECKER_AUTH_DISABLED = "1";
+      const app = await buildApp(stubCtx);
+      const res = await app.inject({
+        method: "POST",
+        url: "/api/flows/recon/runs",
+        payload: { input: { emoji: "\u{1F600}", nfc: "é", nfd: "é" } },
+      });
+      // The guard must not fire (the stub ctx fails later, in the engine, for
+      // unrelated reasons); valid data is never rejected and never re-encoded.
+      expect(res.statusCode).not.toBe(400);
+      expect(res.body).not.toContain("ill-formed Unicode");
+      await app.close();
+    });
+  });
+
   describe("id param validation and error handling", () => {
     afterEach(() => {
       delete process.env.MAKERCHECKER_AUTH_DISABLED;

--- a/packages/server/src/app.ts
+++ b/packages/server/src/app.ts
@@ -4,7 +4,12 @@ import cors from "@fastify/cors";
 import helmet from "@fastify/helmet";
 import rateLimit from "@fastify/rate-limit";
 import swagger from "@fastify/swagger";
-import { isApprovalGate, SCHEMA_VERSION, type FlowDefinition } from "@makerchecker/shared";
+import {
+  findIllFormedString,
+  isApprovalGate,
+  SCHEMA_VERSION,
+  type FlowDefinition,
+} from "@makerchecker/shared";
 import { Type } from "@sinclair/typebox";
 import Fastify, { type FastifyInstance, type FastifyServerOptions } from "fastify";
 
@@ -146,6 +151,26 @@ export async function buildApp(
       "unhandled error",
     );
     return reply.status(500).send({ error: "internal error" });
+  });
+
+  // I-JSON ingress guard (fail closed, one chokepoint for every route): a JSON
+  // body is the only place request-supplied strings enter the audit/hash path
+  // (run trigger input, approval reasons, admin CRUD, proxy payloads), and
+  // JSON.parse happily accepts a lone-surrogate escape ('{"note":"\ud800"}').
+  // Such a string is not I-JSON (RFC 7493), so it has no interoperable RFC 8785
+  // serialization: hashing it would produce a chain event that can never
+  // cross-verify, and the canonicalizer now throws on it deep inside the audit
+  // transaction (a 500). Reject it here, before validation and every handler,
+  // with a clear 400 naming the offending JSON path. Valid data is untouched —
+  // this only rejects input whose hash was never well-defined.
+  app.addHook("preValidation", async (req, reply) => {
+    if (req.body === undefined || req.body === null) return;
+    const path = findIllFormedString(req.body);
+    if (path !== null) {
+      return reply.status(400).send({
+        error: `payload contains ill-formed Unicode (unpaired surrogate) at ${path}`,
+      });
+    }
   });
 
   // Security middleware, registered BEFORE any route so it covers /healthz,

--- a/packages/shared/src/canonical-json.test.ts
+++ b/packages/shared/src/canonical-json.test.ts
@@ -1,6 +1,11 @@
 import { describe, expect, it } from "vitest";
 
-import { CanonicalizationError, canonicalJson } from "./canonical-json.js";
+import {
+  CanonicalizationError,
+  canonicalJson,
+  findIllFormedString,
+  IllFormedStringError,
+} from "./canonical-json.js";
 
 describe("canonicalJson — RFC 8785 conformance", () => {
   it("serializes literals", () => {
@@ -104,5 +109,56 @@ describe("canonicalJson — adversarial inputs", () => {
     expect(() => canonicalJson({ outer: { inner: [1, NaN] } })).toThrow(
       /\$\.outer\.inner\[1\]/,
     );
+  });
+});
+
+describe("canonicalJson — I-JSON (RFC 7493) well-formed strings", () => {
+  it("rejects a lone high surrogate, fail closed, with the JSON path", () => {
+    // Reachable via the API: JSON.parse('{"note":"\ud800"}') succeeds and
+    // yields this exact string. RFC 8785 assumes I-JSON input; hashing the
+    // ES2019 \ud800 escape can never cross-verify in Python/Go.
+    const loneHigh = JSON.parse('{"payload":{"note":"\\ud800"}}') as Record<string, unknown>;
+    expect(() => canonicalJson(loneHigh)).toThrow(IllFormedStringError);
+    expect(() => canonicalJson(loneHigh)).toThrow(
+      "ill-formed Unicode (unpaired surrogate) in string at $.payload.note",
+    );
+    // The typed error is also a CanonicalizationError, so existing catch sites hold.
+    expect(() => canonicalJson(loneHigh)).toThrow(CanonicalizationError);
+  });
+
+  it("rejects a lone low surrogate", () => {
+    expect(() => canonicalJson({ v: "\udfff" })).toThrow(IllFormedStringError);
+    expect(() => canonicalJson({ v: "tail\udc00" })).toThrow(/\$\.v/);
+  });
+
+  it("rejects a reversed pair and a high surrogate followed by a non-low unit", () => {
+    expect(() => canonicalJson(["\udc00\ud800"])).toThrow(/\$\[0\]/);
+    expect(() => canonicalJson({ v: "\ud800x" })).toThrow(IllFormedStringError);
+  });
+
+  it("rejects an unpaired surrogate in an object KEY, naming the member path", () => {
+    const badKey = JSON.parse('{"\\ud800k":1}') as Record<string, unknown>;
+    expect(() => canonicalJson(badKey)).toThrow(IllFormedStringError);
+    expect(() => canonicalJson(badKey)).toThrow(/at \$\./);
+  });
+
+  it("PASSES a valid astral pair (U+1F600) unchanged and serializes it literally", () => {
+    // RFC 8785 emits characters above the escape set literally: the astral
+    // pair must appear as the actual character, never as \\ud83d\\ude00 escapes.
+    expect(canonicalJson({ emoji: "\u{1F600}" })).toBe('{"emoji":"\u{1F600}"}');
+    expect(canonicalJson("\u{1F600}")).toBe('"\u{1F600}"');
+    // NFC/NFD forms stay distinct, byte for byte: no normalization is applied.
+    expect(canonicalJson({ nfc: "\u00e9", nfd: "e\u0301" })).toBe(
+      '{"nfc":"\u00e9","nfd":"e\u0301"}',
+    );
+  });
+
+  it("findIllFormedString reports the same path canonicalJson throws for", () => {
+    const bad = { outer: { list: ["ok", "\ud800"] } };
+    expect(findIllFormedString(bad)).toBe("$.outer.list[1]");
+    expect(() => canonicalJson(bad)).toThrow("$.outer.list[1]");
+    expect(findIllFormedString({ fine: "😀", also: ["é"] })).toBeNull();
+    expect(findIllFormedString("\udc00")).toBe("$");
+    expect(findIllFormedString(42)).toBeNull();
   });
 });

--- a/packages/shared/src/canonical-json.ts
+++ b/packages/shared/src/canonical-json.ts
@@ -8,10 +8,85 @@
  * Rules: no insignificant whitespace; object keys sorted by UTF-16 code units;
  * numbers serialized per ECMAScript Number::toString (which JSON.stringify
  * already implements); non-finite numbers are invalid.
+ *
+ * Input MUST be I-JSON (RFC 7493): every string — key or value — must be
+ * well-formed Unicode. RFC 8785 assumes I-JSON input and leaves an unpaired
+ * surrogate undefined: ES2019 JSON.stringify emits the escape (`\ud800`)
+ * while RFC 8785 implementations in other languages throw or emit different
+ * bytes, so a hash over such a string can never cross-verify. We FAIL CLOSED —
+ * an ill-formed string is rejected (IllFormedStringError) before any bytes are
+ * hashed, identically here and in the standalone proof verifier.
  */
 
 export class CanonicalizationError extends Error {
   override name = "CanonicalizationError";
+}
+
+/** An unpaired surrogate in a string (key or value): the input is not I-JSON. */
+export class IllFormedStringError extends CanonicalizationError {
+  override name = "IllFormedStringError";
+  constructor(readonly path: string) {
+    super(`ill-formed Unicode (unpaired surrogate) in string at ${path}`);
+  }
+}
+
+// String.prototype.isWellFormed is ES2024 (Node >= 20, all modern browsers);
+// captured loosely so the pinned ES2022 lib types need no augmentation.
+const nativeIsWellFormed = (String.prototype as { isWellFormed?: () => boolean })
+  .isWellFormed;
+
+/**
+ * True when `s` contains no unpaired surrogate (is well-formed UTF-16, hence
+ * encodable as UTF-8). Uses String.prototype.isWellFormed where the runtime
+ * provides it; the fallback is a dependency-free O(n) charCodeAt scan.
+ */
+export function isWellFormedString(s: string): boolean {
+  if (nativeIsWellFormed) return nativeIsWellFormed.call(s);
+  for (let i = 0; i < s.length; i += 1) {
+    const unit = s.charCodeAt(i);
+    if (unit >= 0xdc00 && unit <= 0xdfff) return false; // low surrogate with no high before it
+    if (unit >= 0xd800 && unit <= 0xdbff) {
+      const next = i + 1 < s.length ? s.charCodeAt(i + 1) : -1;
+      if (next < 0xdc00 || next > 0xdfff) return false; // high surrogate with no low after it
+      i += 1; // skip the low half of a valid pair
+    }
+  }
+  return true;
+}
+
+function assertWellFormed(s: string, path: string): void {
+  if (!isWellFormedString(s)) throw new IllFormedStringError(path);
+}
+
+/**
+ * Walks a parsed JSON value in the same order canonicalJson serializes it
+ * (object keys sorted, undefined-valued members skipped, each key checked
+ * before its value) and returns the path of the first ill-formed string, or
+ * null when every string is well-formed Unicode. Lets an ingress boundary
+ * reject non-I-JSON input with a clean 4xx — reporting the exact path
+ * canonicalJson would otherwise throw for deep inside a transaction.
+ */
+export function findIllFormedString(value: unknown, path = "$"): string | null {
+  if (typeof value === "string") return isWellFormedString(value) ? null : path;
+  if (typeof value !== "object" || value === null) return null;
+  if (Array.isArray(value)) {
+    for (let i = 0; i < value.length; i += 1) {
+      const found = findIllFormedString(value[i], `${path}[${i}]`);
+      if (found !== null) return found;
+    }
+    return null;
+  }
+  const record = value as Record<string, unknown>;
+  const keys = Object.keys(record)
+    .filter((k) => record[k] !== undefined)
+    .sort();
+  for (const k of keys) {
+    const memberPath = `${path}.${k}`;
+    if (!isWellFormedString(k)) return memberPath;
+    const found = findIllFormedString(record[k], memberPath);
+    if (found !== null) return found;
+  }
+  return null;
 }
 
 export function canonicalJson(value: unknown): string {
@@ -31,6 +106,9 @@ function serialize(value: unknown, path: string): string {
       // JSON.stringify implements the ES number-to-string algorithm RFC 8785 requires.
       return JSON.stringify(value);
     case "string":
+      // FAIL CLOSED before emitting bytes: an unpaired surrogate is not I-JSON
+      // and has no interoperable RFC 8785 serialization (see file header).
+      assertWellFormed(value, path);
       return JSON.stringify(value);
     case "object":
       break;
@@ -56,8 +134,10 @@ function serialize(value: unknown, path: string): string {
   const keys = Object.keys(record)
     .filter((k) => record[k] !== undefined)
     .sort();
-  const members = keys.map(
-    (k) => `${JSON.stringify(k)}:${serialize(record[k], `${path}.${k}`)}`,
-  );
+  const members = keys.map((k) => {
+    // Keys are strings too: check them before serializing, same as values.
+    assertWellFormed(k, `${path}.${k}`);
+    return `${JSON.stringify(k)}:${serialize(record[k], `${path}.${k}`)}`;
+  });
   return `{${members.join(",")}}`;
 }

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -1,4 +1,10 @@
-export { canonicalJson, CanonicalizationError } from "./canonical-json.js";
+export {
+  canonicalJson,
+  CanonicalizationError,
+  findIllFormedString,
+  IllFormedStringError,
+  isWellFormedString,
+} from "./canonical-json.js";
 export {
   AgentStep,
   ApprovalGateApprovals,


### PR DESCRIPTION
## What changed

Fail-closed I-JSON (RFC 7493) enforcement in the production hash chain, fixing the interoperability bug reported by @babyblueviper1 in the external review on PR #66 (and reproduced by us):

- **`packages/shared/src/canonical-json.ts`** — `canonicalJson` now asserts every string (object keys and values) is well-formed Unicode before serializing. An unpaired surrogate throws a typed `IllFormedStringError` (subclass of `CanonicalizationError`, so existing catch sites hold) naming the exact JSON path via the existing path mechanism (`$.payload.note`). The check uses `String.prototype.isWellFormed` where the runtime provides it, with a dependency-free O(n) `charCodeAt` fallback. Also exports `findIllFormedString`, which walks a parsed JSON value in serialization order and reports the same path, for ingress boundaries.
- **`packages/server/src/app.ts`** — one validation chokepoint: an app-level `preValidation` hook rejects any request body containing an unpaired surrogate with `400 {"error":"payload contains ill-formed Unicode (unpaired surrogate) at $.input.note"}`. The JSON body is the only path request-supplied strings take into the audit/hash write path (run trigger input, approval decisions/reasons, admin CRUD, proxy payloads — all Fastify JSON bodies; no YAML or other parsers exist in server src), so this guards every entry route and prevents a 500 from the deep throw mid-transaction.
- **`docs/audit-spec.md`** — the spec now states the I-JSON requirement and fail-closed rejection semantics, the no-normalization / literal-emission guarantee, and pins the `occurredAt` grammar (`YYYY-MM-DDTHH:MM:SS.mmmZ`) instead of only an example (the review's secondary finding).
- **Tests** — `canonical-json.test.ts`: lone high surrogate (the API-reachable `JSON.parse('{"note":"\ud800"}')` repro), lone low surrogate, reversed pair, unpaired surrogate in a key, and a positive case proving a valid astral pair (U+1F600) passes unchanged and serializes literally with NFC/NFD forms kept distinct. `app.test.ts`: the API returns 400 (not 500) for surrogates in run input, in an object key, and in an approval reason; well-formed astral/NFC/NFD input passes the guard untouched.

## Why

RFC 8785 presumes I-JSON input and leaves an unpaired surrogate undefined. `JSON.parse('{"note":"\ud800"}')` succeeds, and our ES2019 `JSON.stringify`-based canonicalizer serialized the lone surrogate as the `\ud800` escape — bytes that Python/Go RFC 8785 implementations do not reproduce (they throw or emit different bytes). A legitimate bundle containing such an event hashes one way in JS only and fails cross-language verification. Reproduced: `canonicalJson({payload:{note:"\ud800"}})` returned `{"payload":{"note":"\ud800"}}` (bytes `5c7564383030`). The fix philosophy is fail closed: ill-formed Unicode is rejected before hashing, with identical semantics in producer and verifier (verifier side lands in the stacked PR off `feat/proof-verifier`). Hashes of valid data are unchanged — this only rejects input whose serialization was never interoperably defined.

## Verification

- `packages/shared`: `vitest run` — **4 files, 54 tests passed** (includes the 6 new I-JSON tests).
- `packages/server`: full suite `vitest run` — **Tests 800 passed | 1 skipped (801)**. One suite (`owner-db-warning.integration.test.ts`) hit a pre-existing parallel-worker `CREATE ROLE` collision (`mc_app_runtime already exists` from `ops/harden-db.sql`); it passes in isolation (`6 passed (6)`) and is unrelated to this change.
- `tsc --noEmit` and `eslint` clean for both packages.
- Cross-check against the verifier port (posted in the stacked PR): 4 valid inputs byte-identical, 6 ill-formed inputs identically rejected with the same class/message/path; the `charCodeAt` fallback agrees with native `isWellFormed` on all cases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
