### PR TITLE
Verifier: reject ill-formed strings as I-JSON spec violation, distinct from tamper

### DIFF
--- a/packages/proof-verifier/README.md
+++ b/packages/proof-verifier/README.md
@@ -51,7 +51,7 @@ const result = await verifyBundle(bundle, nodeCrypto, {
   expectedPublicKeyPem, // optional out-of-band key pinning
 });
 // { ok: true, count, bundleKind, headHash, keyFingerprint }
-// | { ok: false, reason, failedSeq? }
+// | { ok: false, reason, reasonCode?, failedSeq?, path? }
 ```
 
 The core (`@makerchecker/proof-verifier/core`) is isomorphic: all cryptography
@@ -71,12 +71,44 @@ Per the [audit spec](../../docs/audit-spec.md):
 6. **Head & bounds** — head hash and first/last seq match the manifest.
 7. **Key pinning (optional)** — rejects a bundle re-signed with any key but the pinned one.
 
+### Spec-violation verdicts (distinct from tamper)
+
+The spec requires hashed input to be **I-JSON (RFC 7493)**: every string —
+object key or value — must be well-formed Unicode. RFC 8785 presumes I-JSON
+and defines no interoperable byte sequence for an unpaired surrogate
+(implementations disagree: ES2019 `JSON.stringify` emits a `\ud800` escape,
+Python/Go RFC 8785 libraries throw or emit different bytes), so a hash over
+such a string can never cross-verify. When a bundle contains one, the verifier
+returns a **machine-readable spec-violation reject**, deliberately distinct
+from a tamper verdict:
+
+```js
+{
+  ok: false,
+  reasonCode: "ill_formed_string", // machine-readable verdict class
+  failedSeq: "9",                  // the offending event (absent for a manifest string)
+  path: "$.payload.note",          // JSON path of the ill-formed string
+  reason: "event seq 9 contains an ill-formed string (unpaired surrogate) at $.payload.note: ..."
+}
+```
+
+`ill_formed_string` proves nothing was altered — it says the bundle violates
+the spec's I-JSON requirement, its hashes were never well-defined, and it must
+not be accepted. Producers running the fixed pipeline can no longer emit such
+bundles (ill-formed strings are rejected at API ingress with HTTP 400 and by
+the serializer itself, fail closed). No Unicode normalization is ever applied:
+NFC and NFD strings are distinct bytes, and characters outside JSON's
+mandatory escape set (including astral characters like U+1F600) are hashed and
+emitted literally — the `unicode-literal` vector proves both properties.
+
 ## Conformance vectors
 
-[`vectors/`](./vectors) is a public corpus: valid full and run bundles plus
-adversarial variants (tampered payload, corrupted signature, truncation,
-reordering, a re-signed foreign-run splice, and a wrong-key forgery), each with
-the verdict a conformant verifier must return in
+[`vectors/`](./vectors) is a public corpus: valid full and run bundles (one
+with astral + NFC/NFD strings proving literal, unnormalized Unicode handling)
+plus adversarial variants (tampered payload, corrupted signature, truncation,
+reordering, a re-signed foreign-run splice, a wrong-key forgery, and an
+ill-formed-string bundle that must be rejected as an I-JSON spec violation),
+each with the verdict a conformant verifier must return in
 [`vectors/index.json`](./vectors/index.json). Any implementation in any language
 can run these and self-certify.
 

--- a/packages/proof-verifier/scripts/build-vectors.mjs
+++ b/packages/proof-verifier/scripts/build-vectors.mjs
@@ -176,6 +176,39 @@ function main() {
   //    PASSES on its own and FAILS only when the real key is pinned.
   const wrongKey = makeBundle(events, { instanceId, privateKey: attacker.privateKey, publicKeyPem: attackerPubPem, exportedAt, bundleKind: "full", runId: null });
 
+  // 7. ill-formed-string: the last event's payload carries an unpaired
+  //    surrogate (reachable in production via JSON.parse('{"note":"\ud800"}')).
+  //    Its stored hash is over the exact bytes the buggy pre-I-JSON JS producer
+  //    emitted (ES2019 JSON.stringify escapes a lone surrogate as \ud800 —
+  //    bytes no other language's RFC 8785 implementation reproduces), so this
+  //    is precisely the bundle such a producer would have signed. A conformant
+  //    verifier must REJECT it as a spec violation (reasonCode
+  //    ill_formed_string) — not report tamper, and never "verify" it with
+  //    JS-only semantics. The placeholder trick below recreates the legacy
+  //    bytes without keeping a second, lenient serializer in the corpus.
+  const PLACEHOLDER = "__ILL_FORMED_STRING_PLACEHOLDER__";
+  const illSpecs = [
+    ...specs,
+    { id: randomUUID(), occurred_at: t(8), actor: agent, event_type: "note.recorded", run_id: runId, payload: { note: PLACEHOLDER } },
+  ];
+  const illEvents = buildChain(instanceId, illSpecs);
+  const illLast = illEvents[illEvents.length - 1];
+  illLast.hash = sha256Hex(canonicalJson(hashInput(illLast)).replace(`"${PLACEHOLDER}"`, '"\\ud800"'));
+  illLast.payload.note = "\ud800"; // the actual lone surrogate ships in the vector
+  const illFormedString = makeBundle(illEvents, { ...bundleArgs, bundleKind: "full", runId: null });
+
+  // 8. unicode-literal (POSITIVE): an astral emoji (U+1F600) plus an NFC/NFD
+  //    pair (U+00E9 vs U+0065 U+0301), hashed over the literal code points. It
+  //    must VERIFY: proving the pipeline emits supplementary characters
+  //    literally (RFC 8785 escapes only the mandatory set) and applies no
+  //    Unicode normalization (a normalizing implementation would collapse the
+  //    NFC/NFD pair and fail the hash).
+  const unicodeSpecs = [
+    ...specs,
+    { id: randomUUID(), occurred_at: t(8), actor: agent, event_type: "note.recorded", run_id: runId, payload: { emoji: "\u{1F600}", nfc: "\u00e9", nfd: "e\u0301" } },
+  ];
+  const unicodeLiteral = makeBundle(buildChain(instanceId, unicodeSpecs), { ...bundleArgs, bundleKind: "full", runId: null });
+
   const write = (name, obj) => writeFileSync(join(VECTORS_DIR, name), JSON.stringify(obj, null, 2) + "\n");
   write("valid-full.json", validFull);
   write("valid-run.json", validRun);
@@ -185,6 +218,8 @@ function main() {
   write("reordered.json", reordered);
   write("foreign-run-event.json", foreignRunEvent);
   write("wrong-key.json", wrongKey);
+  write("ill-formed-string.json", illFormedString);
+  write("unicode-literal.json", unicodeLiteral);
   writeFileSync(join(VECTORS_DIR, "instance-pubkey.pem"), publicKeyPem);
 
   const index = {
@@ -201,6 +236,8 @@ function main() {
       { file: "foreign-run-event.json", expect: "fail", reasonContains: "does not belong to run", note: "re-signed bundle with a foreign-run event spliced in" },
       { file: "wrong-key.json", expect: "pass", note: "internally valid under its own (attacker) key when NOT pinned" },
       { file: "wrong-key.json", expect: "fail", pinKey: "instance-pubkey.pem", reasonContains: "pinned key", note: "same bundle rejected once the real key is pinned" },
+      { file: "unicode-literal.json", expect: "pass", note: "astral emoji + NFC/NFD pair hashed over literal code points: no escaping beyond the mandatory set, no Unicode normalization" },
+      { file: "ill-formed-string.json", expect: "fail", reasonCode: "ill_formed_string", reasonContains: "ill-formed string", note: "an event payload carries an unpaired surrogate: I-JSON (RFC 7493) spec violation, a verdict distinct from tamper" },
     ],
   };
   writeFileSync(join(VECTORS_DIR, "index.json"), JSON.stringify(index, null, 2) + "\n");

--- a/packages/proof-verifier/scripts/test.mjs
+++ b/packages/proof-verifier/scripts/test.mjs
@@ -42,6 +42,10 @@ for (const c of index.cases) {
     failures.push(`${label}: failed as expected but reason "${result.reason}" lacks "${c.reasonContains}"`);
     continue;
   }
+  if (c.expect === "fail" && c.reasonCode && result.reasonCode !== c.reasonCode) {
+    failures.push(`${label}: expected reasonCode "${c.reasonCode}", got "${result.reasonCode ?? "none"}"`);
+    continue;
+  }
   passed += 1;
   process.stdout.write(`  ok  ${label} -> ${got}${got === "fail" ? ` (${result.reason})` : ` (${result.count} events)`}\n`);
 }

--- a/packages/proof-verifier/src/canonical-json.js
+++ b/packages/proof-verifier/src/canonical-json.js
@@ -12,6 +12,14 @@
  * JSON.stringify implements); non-finite numbers are invalid; members whose
  * value is `undefined` are omitted; `null` serializes as `null`.
  *
+ * Input MUST be I-JSON (RFC 7493): every string — key or value — must be
+ * well-formed Unicode. RFC 8785 assumes I-JSON input and leaves an unpaired
+ * surrogate undefined: ES2019 JSON.stringify emits the escape (`\ud800`)
+ * while RFC 8785 implementations in other languages throw or emit different
+ * bytes, so a hash over such a string can never cross-verify. We FAIL CLOSED —
+ * an ill-formed string is rejected (IllFormedStringError) before any bytes are
+ * hashed, identically here and in the producer's serializer.
+ *
  * Isomorphic: no Node or browser APIs are used here.
  */
 
@@ -20,6 +28,42 @@ export class CanonicalizationError extends Error {
     super(message);
     this.name = "CanonicalizationError";
   }
+}
+
+/** An unpaired surrogate in a string (key or value): the input is not I-JSON. */
+export class IllFormedStringError extends CanonicalizationError {
+  constructor(path) {
+    super(`ill-formed Unicode (unpaired surrogate) in string at ${path}`);
+    this.name = "IllFormedStringError";
+    this.path = path;
+  }
+}
+
+// String.prototype.isWellFormed is ES2024 (Node >= 20, all modern browsers);
+// captured so older runtimes fall through to the scan below.
+const nativeIsWellFormed = String.prototype.isWellFormed;
+
+/**
+ * True when `s` contains no unpaired surrogate (is well-formed UTF-16, hence
+ * encodable as UTF-8). Uses String.prototype.isWellFormed where the runtime
+ * provides it; the fallback is a dependency-free O(n) charCodeAt scan.
+ */
+export function isWellFormedString(s) {
+  if (nativeIsWellFormed) return nativeIsWellFormed.call(s);
+  for (let i = 0; i < s.length; i += 1) {
+    const unit = s.charCodeAt(i);
+    if (unit >= 0xdc00 && unit <= 0xdfff) return false; // low surrogate with no high before it
+    if (unit >= 0xd800 && unit <= 0xdbff) {
+      const next = i + 1 < s.length ? s.charCodeAt(i + 1) : -1;
+      if (next < 0xdc00 || next > 0xdfff) return false; // high surrogate with no low after it
+      i += 1; // skip the low half of a valid pair
+    }
+  }
+  return true;
+}
+
+function assertWellFormed(s, path) {
+  if (!isWellFormedString(s)) throw new IllFormedStringError(path);
 }
 
 export function canonicalJson(value) {
@@ -38,6 +82,9 @@ function serialize(value, path) {
       }
       return JSON.stringify(value);
     case "string":
+      // FAIL CLOSED before emitting bytes: an unpaired surrogate is not I-JSON
+      // and has no interoperable RFC 8785 serialization (see file header).
+      assertWellFormed(value, path);
       return JSON.stringify(value);
     case "object":
       break;
@@ -63,8 +110,10 @@ function serialize(value, path) {
   const keys = Object.keys(value)
     .filter((k) => value[k] !== undefined)
     .sort();
-  const members = keys.map(
-    (k) => `${JSON.stringify(k)}:${serialize(value[k], `${path}.${k}`)}`,
-  );
+  const members = keys.map((k) => {
+    // Keys are strings too: check them before serializing, same as values.
+    assertWellFormed(k, `${path}.${k}`);
+    return `${JSON.stringify(k)}:${serialize(value[k], `${path}.${k}`)}`;
+  });
   return `{${members.join(",")}}`;
 }

--- a/packages/proof-verifier/src/index.js
+++ b/packages/proof-verifier/src/index.js
@@ -7,5 +7,10 @@
  */
 
 export { verifyBundle, GENESIS_PREFIX } from "./verify-core.js";
-export { canonicalJson, CanonicalizationError } from "./canonical-json.js";
+export {
+  canonicalJson,
+  CanonicalizationError,
+  IllFormedStringError,
+  isWellFormedString,
+} from "./canonical-json.js";
 export { nodeCrypto } from "./node-crypto.js";

--- a/packages/proof-verifier/src/verify-core.js
+++ b/packages/proof-verifier/src/verify-core.js
@@ -16,7 +16,7 @@
  * (`docs/audit-spec.md`, schema version 1).
  */
 
-import { canonicalJson } from "./canonical-json.js";
+import { canonicalJson, IllFormedStringError } from "./canonical-json.js";
 
 /**
  * Genesis derivation prefix, fixed by the audit spec (schema version 1):
@@ -64,7 +64,14 @@ function fail(reason, extra) {
  * Verifies a bundle. Returns
  *   { ok: true, count, bundleKind, headHash, keyFingerprint }
  * or
- *   { ok: false, reason, failedSeq? }.
+ *   { ok: false, reason, reasonCode?, failedSeq?, path? }.
+ *
+ * `reasonCode` is set for machine-distinguishable verdict classes; today the
+ * only code is "ill_formed_string": the bundle violates the spec's I-JSON
+ * (RFC 7493) requirement — an unpaired surrogate in a hashed string — so its
+ * hash is not well-defined under RFC 8785. That is a SPEC-VIOLATION reject,
+ * deliberately distinct from a tamper verdict: nothing is proven altered, but
+ * the bundle can never cross-verify and must not be accepted.
  *
  * @param {object} bundle  parsed { manifest, events }
  * @param {object} crypto  injected crypto provider (see file header)
@@ -86,9 +93,22 @@ export async function verifyBundle(bundle, crypto, opts = {}) {
   }
 
   // 1. Signature over the canonical signing string (excludes publicKeyPem, signature).
+  let signingString;
+  try {
+    signingString = manifestSigningString(manifest);
+  } catch (err) {
+    if (err instanceof IllFormedStringError) {
+      return fail(
+        `manifest contains an ill-formed string (unpaired surrogate) at ${err.path}: ` +
+          "the spec requires I-JSON (RFC 7493) input, so this bundle can never cross-verify",
+        { reasonCode: "ill_formed_string", path: err.path },
+      );
+    }
+    throw err;
+  }
   const sigOk = await crypto.ed25519Verify(
     manifest.publicKeyPem,
-    manifestSigningString(manifest),
+    signingString,
     manifest.signature,
   );
   if (!sigOk) return fail("manifest signature invalid");
@@ -128,7 +148,25 @@ export async function verifyBundle(bundle, crypto, opts = {}) {
       ? await crypto.sha256Hex(GENESIS_PREFIX + manifest.instanceId)
       : null;
   for (const event of events) {
-    const recomputed = await crypto.sha256Hex(canonicalJson(hashInput(event)));
+    let recomputed;
+    try {
+      recomputed = await crypto.sha256Hex(canonicalJson(hashInput(event)));
+    } catch (err) {
+      if (err instanceof IllFormedStringError) {
+        // Spec-violation verdict, distinct from tamper: the event carries a
+        // string that is not I-JSON (RFC 7493), so RFC 8785 defines no bytes
+        // to hash. The buggy pre-I-JSON JS producer emitted the ES2019 \uXXXX
+        // escape here, which no other language's RFC 8785 implementation
+        // reproduces — accepting it would "verify" JS-only semantics. Reject,
+        // fail closed, with the seq and JSON path machine-readable.
+        return fail(
+          `event seq ${event.seq} contains an ill-formed string (unpaired surrogate) at ${err.path}: ` +
+            "the spec requires I-JSON (RFC 7493) input, so this bundle can never cross-verify",
+          { reasonCode: "ill_formed_string", failedSeq: event.seq, path: err.path },
+        );
+      }
+      throw err;
+    }
     if (recomputed !== event.hash) {
       return fail(`event seq ${event.seq} hash mismatch (row tampered)`, { failedSeq: event.seq });
     }

--- a/packages/proof-verifier/vectors/ill-formed-string.json
+++ b/packages/proof-verifier/vectors/ill-formed-string.json
@@ -1,19 +1,37 @@
 {
   "manifest": {
-    "bundleKind": "run",
+    "bundleKind": "full",
     "schemaVersion": 1,
     "instanceId": "11111111-1111-4111-8111-111111111111",
     "exportedAt": "2026-06-12T10:00:00.000Z",
-    "runId": "22222222-2222-4222-8222-222222222222",
-    "count": 8,
-    "firstSeq": "2",
-    "lastSeq": "8",
-    "headHash": "f5ab5d1e8308b03d7bec7ff95826980559cdfcf7fbd97caa574a7110c87503f2",
-    "eventHashesDigest": "63f8ea885390881348d5752fa62a40ef527aa45f8d9639f4ecd9796a212e7d86",
+    "runId": null,
+    "count": 9,
+    "firstSeq": "1",
+    "lastSeq": "9",
+    "headHash": "c32b2b33bcbcb61b05ebb9dc1160be06230b8ffc42c75849e0eecdbb925272c6",
+    "eventHashesDigest": "1f41871f0293be381f7f2267d193246ebfac8470960afcb4cb1423509d5feb20",
     "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMCowBQYDK2VwAyEAtAZrcPkaCk+v8mKz+NYQhe8V3qHlMnjwG5pzpSgYa18=\n-----END PUBLIC KEY-----\n",
-    "signature": "YDPVk6k9KYp1O7GsZ33lPYt5n4atgSrHwlBh2OAWjCQEGvD9Al9Nmg18pjO3WVCJmZukUsalBpgFzNLwwux4Ag=="
+    "signature": "4mMTFZFNB7ZOfEdpUy6DnArSesKENixfYfHzeTMNx7YE0WFX9be4FPPhNfwvWP5cSTuSJF7Dd4eURSaYoLkODA=="
   },
   "events": [
+    {
+      "seq": "1",
+      "id": "3a9cd439-910a-436d-befd-1c0bb76fd479",
+      "occurred_at": "2026-06-12T09:30:00.000Z",
+      "actor": {
+        "kind": "system",
+        "id": "instance"
+      },
+      "event_type": "audit.genesis",
+      "entity_type": null,
+      "entity_id": null,
+      "run_id": null,
+      "payload": {
+        "instanceId": "11111111-1111-4111-8111-111111111111"
+      },
+      "prev_hash": "a3223803bd3572c34689d246ee3c15b0c385d9d092cf9c9450dff59c32bf0b30",
+      "hash": "9958ab1671c49af7902ec5dbaafdcb9d8603ab3b835fb7a6926b1fcd40c53a71"
+    },
     {
       "seq": "2",
       "id": "a3bf4c66-cf44-4254-a2b6-df5ce312a3cf",
@@ -73,25 +91,6 @@
       },
       "prev_hash": "015e435097136a3fa9455d4853beadff18fb3ce45d3056cccac07b9937ee44ad",
       "hash": "9ad04a2cc71b961a1a6f8239e4d5f0b3de823736df4606f9f4e3f939bff9786c"
-    },
-    {
-      "seq": "99",
-      "entity_type": null,
-      "entity_id": null,
-      "prev_hash": "9ad04a2cc71b961a1a6f8239e4d5f0b3de823736df4606f9f4e3f939bff9786c",
-      "id": "b498dd93-a24d-4732-9549-07ad6f9d7bc2",
-      "occurred_at": "2026-06-12T09:35:00.000Z",
-      "actor": {
-        "kind": "agent",
-        "id": "agent-0001",
-        "role": "case-processor"
-      },
-      "event_type": "skill.invoked",
-      "run_id": "33333333-3333-4333-8333-333333333333",
-      "payload": {
-        "skill": "x"
-      },
-      "hash": "d00563cb81c80b3bd87e83ec463ce284e8b73333cdcaf55f6778f72e9d9a4100"
     },
     {
       "seq": "5",
@@ -172,6 +171,25 @@
       },
       "prev_hash": "1cbfd5cfada2d4a5b330f3e941c236f1ab3bd59cfba3ee9daf47eb032dd00515",
       "hash": "f5ab5d1e8308b03d7bec7ff95826980559cdfcf7fbd97caa574a7110c87503f2"
+    },
+    {
+      "seq": "9",
+      "id": "d488d4de-4fce-4464-b730-17f4e0bed0dc",
+      "occurred_at": "2026-06-12T09:38:00.000Z",
+      "actor": {
+        "kind": "agent",
+        "id": "agent-0001",
+        "role": "case-processor"
+      },
+      "event_type": "note.recorded",
+      "entity_type": null,
+      "entity_id": null,
+      "run_id": "22222222-2222-4222-8222-222222222222",
+      "payload": {
+        "note": "\ud800"
+      },
+      "prev_hash": "f5ab5d1e8308b03d7bec7ff95826980559cdfcf7fbd97caa574a7110c87503f2",
+      "hash": "c32b2b33bcbcb61b05ebb9dc1160be06230b8ffc42c75849e0eecdbb925272c6"
     }
   ]
 }

--- a/packages/proof-verifier/vectors/index.json
+++ b/packages/proof-verifier/vectors/index.json
@@ -59,6 +59,18 @@
       "pinKey": "instance-pubkey.pem",
       "reasonContains": "pinned key",
       "note": "same bundle rejected once the real key is pinned"
+    },
+    {
+      "file": "unicode-literal.json",
+      "expect": "pass",
+      "note": "astral emoji + NFC/NFD pair hashed over literal code points: no escaping beyond the mandatory set, no Unicode normalization"
+    },
+    {
+      "file": "ill-formed-string.json",
+      "expect": "fail",
+      "reasonCode": "ill_formed_string",
+      "reasonContains": "ill-formed string",
+      "note": "an event payload carries an unpaired surrogate: I-JSON (RFC 7493) spec violation, a verdict distinct from tamper"
     }
   ]
 }

--- a/packages/proof-verifier/vectors/reordered.json
+++ b/packages/proof-verifier/vectors/reordered.json
@@ -8,15 +8,15 @@
     "count": 8,
     "firstSeq": "1",
     "lastSeq": "8",
-    "headHash": "08664a25e2828506f5d943e6ae9703cb542da630c6cb0509d2c0c944638ee5b3",
-    "eventHashesDigest": "c66264a199f3753e0fbad03b065617154b85b87af975d50acfc1b5012c0dceb7",
-    "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMCowBQYDK2VwAyEAnKdCt10Ts7ExQIzFvO2ME06hpng7uY5F4yjtKLOXW04=\n-----END PUBLIC KEY-----\n",
-    "signature": "SopGjkctNALSUcyBobWBX9Pjtct3mud06wPRkULa7DZxJ/VoL7kTOkiGiGizbyLy0acD4uzgXryS+qP7iZZnCA=="
+    "headHash": "f5ab5d1e8308b03d7bec7ff95826980559cdfcf7fbd97caa574a7110c87503f2",
+    "eventHashesDigest": "b24e414ea6d84f067c41037513a52b1b863d3c2cf95fe0cf927ad1f8e43fc51a",
+    "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMCowBQYDK2VwAyEAtAZrcPkaCk+v8mKz+NYQhe8V3qHlMnjwG5pzpSgYa18=\n-----END PUBLIC KEY-----\n",
+    "signature": "SYl51nvfZX6ezpWBMXdItcJ45aBS1O1RoRVX+F7rctDJbKfMpALufkfwE0Mhpe5dqSuxS4DaqEW/O68MJjMXAA=="
   },
   "events": [
     {
       "seq": "1",
-      "id": "5deb576a-a2dc-4e3d-8af1-96c0e2f240e7",
+      "id": "3a9cd439-910a-436d-befd-1c0bb76fd479",
       "occurred_at": "2026-06-12T09:30:00.000Z",
       "actor": {
         "kind": "system",
@@ -30,11 +30,11 @@
         "instanceId": "11111111-1111-4111-8111-111111111111"
       },
       "prev_hash": "a3223803bd3572c34689d246ee3c15b0c385d9d092cf9c9450dff59c32bf0b30",
-      "hash": "383904a6ed018b1fb36e082a53644c803311a86fd69e86aaa048eeddf9b8dd2c"
+      "hash": "9958ab1671c49af7902ec5dbaafdcb9d8603ab3b835fb7a6926b1fcd40c53a71"
     },
     {
       "seq": "2",
-      "id": "ae6557d9-6ceb-472c-9df2-40c594df28b3",
+      "id": "a3bf4c66-cf44-4254-a2b6-df5ce312a3cf",
       "occurred_at": "2026-06-12T09:31:00.000Z",
       "actor": {
         "kind": "agent",
@@ -48,12 +48,12 @@
       "payload": {
         "flow": "pv-icsr-processing"
       },
-      "prev_hash": "383904a6ed018b1fb36e082a53644c803311a86fd69e86aaa048eeddf9b8dd2c",
-      "hash": "56f146d988c8719ba781082b224e3cdec0b1cad84d502dbff4dcd44bee32394c"
+      "prev_hash": "9958ab1671c49af7902ec5dbaafdcb9d8603ab3b835fb7a6926b1fcd40c53a71",
+      "hash": "2b54c3b14d6a65ca7f6c017c1284fc048fd469ba82cea60ae7da2f77412731fb"
     },
     {
       "seq": "4",
-      "id": "2c9c383e-4729-4710-82e5-44bd1403f865",
+      "id": "b49c97f6-905a-4ed6-bc6c-79052df12a77",
       "occurred_at": "2026-06-12T09:33:00.000Z",
       "actor": {
         "kind": "agent",
@@ -69,12 +69,12 @@
         "at": "decision",
         "skill": "e2b-submit@1.0.0"
       },
-      "prev_hash": "7c98c3ae7ad6d2ab6b75829a3c40481db262722bf04732715500c10519150e4b",
-      "hash": "ca3c15dd6ca8e19facaacdc86f9f1e8c6b977673e1f480a787fdbc77159e4d0a"
+      "prev_hash": "015e435097136a3fa9455d4853beadff18fb3ce45d3056cccac07b9937ee44ad",
+      "hash": "9ad04a2cc71b961a1a6f8239e4d5f0b3de823736df4606f9f4e3f939bff9786c"
     },
     {
       "seq": "3",
-      "id": "1ee34ed8-09de-455d-9c3d-d3874cd6adb0",
+      "id": "99f2e17a-433f-4b10-bde3-63cab6f6ce8b",
       "occurred_at": "2026-06-12T09:32:00.000Z",
       "actor": {
         "kind": "agent",
@@ -89,12 +89,12 @@
         "model": "claude",
         "tokens": 412
       },
-      "prev_hash": "56f146d988c8719ba781082b224e3cdec0b1cad84d502dbff4dcd44bee32394c",
-      "hash": "7c98c3ae7ad6d2ab6b75829a3c40481db262722bf04732715500c10519150e4b"
+      "prev_hash": "2b54c3b14d6a65ca7f6c017c1284fc048fd469ba82cea60ae7da2f77412731fb",
+      "hash": "015e435097136a3fa9455d4853beadff18fb3ce45d3056cccac07b9937ee44ad"
     },
     {
       "seq": "5",
-      "id": "39ce56bf-ef30-4d77-a74f-9bb3158da3ee",
+      "id": "31c20cde-7148-4c2c-a622-f07c5c363866",
       "occurred_at": "2026-06-12T09:34:00.000Z",
       "actor": {
         "kind": "agent",
@@ -109,12 +109,12 @@
         "gate": "medical-review",
         "skill": "e2b-submit@1.0.0"
       },
-      "prev_hash": "ca3c15dd6ca8e19facaacdc86f9f1e8c6b977673e1f480a787fdbc77159e4d0a",
-      "hash": "c39df83422f73aed594e19e40a909804c4ee480396aa0b5d71755c543549db62"
+      "prev_hash": "9ad04a2cc71b961a1a6f8239e4d5f0b3de823736df4606f9f4e3f939bff9786c",
+      "hash": "57f8a59bafeae2f826d31629862688a46c1515a147a3e62702ba0fa4565b2a25"
     },
     {
       "seq": "6",
-      "id": "9999bca3-ae59-47cf-b837-96e420358f23",
+      "id": "e4669a21-bf23-4060-a4cd-1b5d5e08bf30",
       "occurred_at": "2026-06-12T09:35:00.000Z",
       "actor": {
         "kind": "user",
@@ -130,12 +130,12 @@
         "decider": "user-0009",
         "reason": "Seriousness confirmed for P-4003; file 15-day expedited ICSR per 21 CFR 314.80"
       },
-      "prev_hash": "c39df83422f73aed594e19e40a909804c4ee480396aa0b5d71755c543549db62",
-      "hash": "2371e189d827c2a7ff0b118aa69fb617f8b3a5f5c735c551af419a356edac73a"
+      "prev_hash": "57f8a59bafeae2f826d31629862688a46c1515a147a3e62702ba0fa4565b2a25",
+      "hash": "ca3a64bd883cbec2ddf11974f9f8fca1cebb732687e5c8f8277821ddec716709"
     },
     {
       "seq": "7",
-      "id": "32ab037c-7a91-499b-b3e7-70897eb171e4",
+      "id": "cc4c6781-4f65-4a85-94d4-6f646c6525d9",
       "occurred_at": "2026-06-12T09:36:00.000Z",
       "actor": {
         "kind": "agent",
@@ -150,12 +150,12 @@
         "skill": "e2b-submit@1.0.0",
         "outcome": "filed"
       },
-      "prev_hash": "2371e189d827c2a7ff0b118aa69fb617f8b3a5f5c735c551af419a356edac73a",
-      "hash": "219870cd84785c6b0d52c671087d937e63b659325bff852f0657f418cb580131"
+      "prev_hash": "ca3a64bd883cbec2ddf11974f9f8fca1cebb732687e5c8f8277821ddec716709",
+      "hash": "1cbfd5cfada2d4a5b330f3e941c236f1ab3bd59cfba3ee9daf47eb032dd00515"
     },
     {
       "seq": "8",
-      "id": "313c0875-9cb6-4f9a-be10-448559f1316b",
+      "id": "4154b87f-6db0-468e-b406-62374019d076",
       "occurred_at": "2026-06-12T09:37:00.000Z",
       "actor": {
         "kind": "agent",
@@ -169,8 +169,8 @@
       "payload": {
         "status": "completed"
       },
-      "prev_hash": "219870cd84785c6b0d52c671087d937e63b659325bff852f0657f418cb580131",
-      "hash": "08664a25e2828506f5d943e6ae9703cb542da630c6cb0509d2c0c944638ee5b3"
+      "prev_hash": "1cbfd5cfada2d4a5b330f3e941c236f1ab3bd59cfba3ee9daf47eb032dd00515",
+      "hash": "f5ab5d1e8308b03d7bec7ff95826980559cdfcf7fbd97caa574a7110c87503f2"
     }
   ]
 }

--- a/packages/proof-verifier/vectors/tampered-payload.json
+++ b/packages/proof-verifier/vectors/tampered-payload.json
@@ -8,15 +8,15 @@
     "count": 8,
     "firstSeq": "1",
     "lastSeq": "8",
-    "headHash": "08664a25e2828506f5d943e6ae9703cb542da630c6cb0509d2c0c944638ee5b3",
-    "eventHashesDigest": "c66264a199f3753e0fbad03b065617154b85b87af975d50acfc1b5012c0dceb7",
-    "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMCowBQYDK2VwAyEAnKdCt10Ts7ExQIzFvO2ME06hpng7uY5F4yjtKLOXW04=\n-----END PUBLIC KEY-----\n",
-    "signature": "SopGjkctNALSUcyBobWBX9Pjtct3mud06wPRkULa7DZxJ/VoL7kTOkiGiGizbyLy0acD4uzgXryS+qP7iZZnCA=="
+    "headHash": "f5ab5d1e8308b03d7bec7ff95826980559cdfcf7fbd97caa574a7110c87503f2",
+    "eventHashesDigest": "b24e414ea6d84f067c41037513a52b1b863d3c2cf95fe0cf927ad1f8e43fc51a",
+    "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMCowBQYDK2VwAyEAtAZrcPkaCk+v8mKz+NYQhe8V3qHlMnjwG5pzpSgYa18=\n-----END PUBLIC KEY-----\n",
+    "signature": "SYl51nvfZX6ezpWBMXdItcJ45aBS1O1RoRVX+F7rctDJbKfMpALufkfwE0Mhpe5dqSuxS4DaqEW/O68MJjMXAA=="
   },
   "events": [
     {
       "seq": "1",
-      "id": "5deb576a-a2dc-4e3d-8af1-96c0e2f240e7",
+      "id": "3a9cd439-910a-436d-befd-1c0bb76fd479",
       "occurred_at": "2026-06-12T09:30:00.000Z",
       "actor": {
         "kind": "system",
@@ -30,11 +30,11 @@
         "instanceId": "11111111-1111-4111-8111-111111111111"
       },
       "prev_hash": "a3223803bd3572c34689d246ee3c15b0c385d9d092cf9c9450dff59c32bf0b30",
-      "hash": "383904a6ed018b1fb36e082a53644c803311a86fd69e86aaa048eeddf9b8dd2c"
+      "hash": "9958ab1671c49af7902ec5dbaafdcb9d8603ab3b835fb7a6926b1fcd40c53a71"
     },
     {
       "seq": "2",
-      "id": "ae6557d9-6ceb-472c-9df2-40c594df28b3",
+      "id": "a3bf4c66-cf44-4254-a2b6-df5ce312a3cf",
       "occurred_at": "2026-06-12T09:31:00.000Z",
       "actor": {
         "kind": "agent",
@@ -48,12 +48,12 @@
       "payload": {
         "flow": "pv-icsr-processing"
       },
-      "prev_hash": "383904a6ed018b1fb36e082a53644c803311a86fd69e86aaa048eeddf9b8dd2c",
-      "hash": "56f146d988c8719ba781082b224e3cdec0b1cad84d502dbff4dcd44bee32394c"
+      "prev_hash": "9958ab1671c49af7902ec5dbaafdcb9d8603ab3b835fb7a6926b1fcd40c53a71",
+      "hash": "2b54c3b14d6a65ca7f6c017c1284fc048fd469ba82cea60ae7da2f77412731fb"
     },
     {
       "seq": "3",
-      "id": "1ee34ed8-09de-455d-9c3d-d3874cd6adb0",
+      "id": "99f2e17a-433f-4b10-bde3-63cab6f6ce8b",
       "occurred_at": "2026-06-12T09:32:00.000Z",
       "actor": {
         "kind": "agent",
@@ -68,12 +68,12 @@
         "model": "claude",
         "tokens": 412
       },
-      "prev_hash": "56f146d988c8719ba781082b224e3cdec0b1cad84d502dbff4dcd44bee32394c",
-      "hash": "7c98c3ae7ad6d2ab6b75829a3c40481db262722bf04732715500c10519150e4b"
+      "prev_hash": "2b54c3b14d6a65ca7f6c017c1284fc048fd469ba82cea60ae7da2f77412731fb",
+      "hash": "015e435097136a3fa9455d4853beadff18fb3ce45d3056cccac07b9937ee44ad"
     },
     {
       "seq": "4",
-      "id": "2c9c383e-4729-4710-82e5-44bd1403f865",
+      "id": "b49c97f6-905a-4ed6-bc6c-79052df12a77",
       "occurred_at": "2026-06-12T09:33:00.000Z",
       "actor": {
         "kind": "agent",
@@ -89,12 +89,12 @@
         "at": "decision",
         "skill": "e2b-submit@1.0.0"
       },
-      "prev_hash": "7c98c3ae7ad6d2ab6b75829a3c40481db262722bf04732715500c10519150e4b",
-      "hash": "ca3c15dd6ca8e19facaacdc86f9f1e8c6b977673e1f480a787fdbc77159e4d0a"
+      "prev_hash": "015e435097136a3fa9455d4853beadff18fb3ce45d3056cccac07b9937ee44ad",
+      "hash": "9ad04a2cc71b961a1a6f8239e4d5f0b3de823736df4606f9f4e3f939bff9786c"
     },
     {
       "seq": "5",
-      "id": "39ce56bf-ef30-4d77-a74f-9bb3158da3ee",
+      "id": "31c20cde-7148-4c2c-a622-f07c5c363866",
       "occurred_at": "2026-06-12T09:34:00.000Z",
       "actor": {
         "kind": "agent",
@@ -109,12 +109,12 @@
         "gate": "medical-review",
         "skill": "e2b-submit@1.0.0"
       },
-      "prev_hash": "ca3c15dd6ca8e19facaacdc86f9f1e8c6b977673e1f480a787fdbc77159e4d0a",
-      "hash": "c39df83422f73aed594e19e40a909804c4ee480396aa0b5d71755c543549db62"
+      "prev_hash": "9ad04a2cc71b961a1a6f8239e4d5f0b3de823736df4606f9f4e3f939bff9786c",
+      "hash": "57f8a59bafeae2f826d31629862688a46c1515a147a3e62702ba0fa4565b2a25"
     },
     {
       "seq": "6",
-      "id": "9999bca3-ae59-47cf-b837-96e420358f23",
+      "id": "e4669a21-bf23-4060-a4cd-1b5d5e08bf30",
       "occurred_at": "2026-06-12T09:35:00.000Z",
       "actor": {
         "kind": "user",
@@ -130,12 +130,12 @@
         "decider": "user-0009",
         "reason": "Seriousness confirmed for P-4003; file 15-day expedited ICSR per 21 CFR 314.80"
       },
-      "prev_hash": "c39df83422f73aed594e19e40a909804c4ee480396aa0b5d71755c543549db62",
-      "hash": "2371e189d827c2a7ff0b118aa69fb617f8b3a5f5c735c551af419a356edac73a"
+      "prev_hash": "57f8a59bafeae2f826d31629862688a46c1515a147a3e62702ba0fa4565b2a25",
+      "hash": "ca3a64bd883cbec2ddf11974f9f8fca1cebb732687e5c8f8277821ddec716709"
     },
     {
       "seq": "7",
-      "id": "32ab037c-7a91-499b-b3e7-70897eb171e4",
+      "id": "cc4c6781-4f65-4a85-94d4-6f646c6525d9",
       "occurred_at": "2026-06-12T09:36:00.000Z",
       "actor": {
         "kind": "agent",
@@ -150,12 +150,12 @@
         "skill": "e2b-submit@1.0.0",
         "outcome": "not-filed"
       },
-      "prev_hash": "2371e189d827c2a7ff0b118aa69fb617f8b3a5f5c735c551af419a356edac73a",
-      "hash": "219870cd84785c6b0d52c671087d937e63b659325bff852f0657f418cb580131"
+      "prev_hash": "ca3a64bd883cbec2ddf11974f9f8fca1cebb732687e5c8f8277821ddec716709",
+      "hash": "1cbfd5cfada2d4a5b330f3e941c236f1ab3bd59cfba3ee9daf47eb032dd00515"
     },
     {
       "seq": "8",
-      "id": "313c0875-9cb6-4f9a-be10-448559f1316b",
+      "id": "4154b87f-6db0-468e-b406-62374019d076",
       "occurred_at": "2026-06-12T09:37:00.000Z",
       "actor": {
         "kind": "agent",
@@ -169,8 +169,8 @@
       "payload": {
         "status": "completed"
       },
-      "prev_hash": "219870cd84785c6b0d52c671087d937e63b659325bff852f0657f418cb580131",
-      "hash": "08664a25e2828506f5d943e6ae9703cb542da630c6cb0509d2c0c944638ee5b3"
+      "prev_hash": "1cbfd5cfada2d4a5b330f3e941c236f1ab3bd59cfba3ee9daf47eb032dd00515",
+      "hash": "f5ab5d1e8308b03d7bec7ff95826980559cdfcf7fbd97caa574a7110c87503f2"
     }
   ]
 }

--- a/packages/proof-verifier/vectors/tampered-signature.json
+++ b/packages/proof-verifier/vectors/tampered-signature.json
@@ -8,15 +8,15 @@
     "count": 8,
     "firstSeq": "1",
     "lastSeq": "8",
-    "headHash": "08664a25e2828506f5d943e6ae9703cb542da630c6cb0509d2c0c944638ee5b3",
-    "eventHashesDigest": "c66264a199f3753e0fbad03b065617154b85b87af975d50acfc1b5012c0dceb7",
-    "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMCowBQYDK2VwAyEAnKdCt10Ts7ExQIzFvO2ME06hpng7uY5F4yjtKLOXW04=\n-----END PUBLIC KEY-----\n",
-    "signature": "AopGjkctNALSUcyBobWBX9Pjtct3mud06wPRkULa7DZxJ/VoL7kTOkiGiGizbyLy0acD4uzgXryS+qP7iZZnCA=="
+    "headHash": "f5ab5d1e8308b03d7bec7ff95826980559cdfcf7fbd97caa574a7110c87503f2",
+    "eventHashesDigest": "b24e414ea6d84f067c41037513a52b1b863d3c2cf95fe0cf927ad1f8e43fc51a",
+    "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMCowBQYDK2VwAyEAtAZrcPkaCk+v8mKz+NYQhe8V3qHlMnjwG5pzpSgYa18=\n-----END PUBLIC KEY-----\n",
+    "signature": "AYl51nvfZX6ezpWBMXdItcJ45aBS1O1RoRVX+F7rctDJbKfMpALufkfwE0Mhpe5dqSuxS4DaqEW/O68MJjMXAA=="
   },
   "events": [
     {
       "seq": "1",
-      "id": "5deb576a-a2dc-4e3d-8af1-96c0e2f240e7",
+      "id": "3a9cd439-910a-436d-befd-1c0bb76fd479",
       "occurred_at": "2026-06-12T09:30:00.000Z",
       "actor": {
         "kind": "system",
@@ -30,11 +30,11 @@
         "instanceId": "11111111-1111-4111-8111-111111111111"
       },
       "prev_hash": "a3223803bd3572c34689d246ee3c15b0c385d9d092cf9c9450dff59c32bf0b30",
-      "hash": "383904a6ed018b1fb36e082a53644c803311a86fd69e86aaa048eeddf9b8dd2c"
+      "hash": "9958ab1671c49af7902ec5dbaafdcb9d8603ab3b835fb7a6926b1fcd40c53a71"
     },
     {
       "seq": "2",
-      "id": "ae6557d9-6ceb-472c-9df2-40c594df28b3",
+      "id": "a3bf4c66-cf44-4254-a2b6-df5ce312a3cf",
       "occurred_at": "2026-06-12T09:31:00.000Z",
       "actor": {
         "kind": "agent",
@@ -48,12 +48,12 @@
       "payload": {
         "flow": "pv-icsr-processing"
       },
-      "prev_hash": "383904a6ed018b1fb36e082a53644c803311a86fd69e86aaa048eeddf9b8dd2c",
-      "hash": "56f146d988c8719ba781082b224e3cdec0b1cad84d502dbff4dcd44bee32394c"
+      "prev_hash": "9958ab1671c49af7902ec5dbaafdcb9d8603ab3b835fb7a6926b1fcd40c53a71",
+      "hash": "2b54c3b14d6a65ca7f6c017c1284fc048fd469ba82cea60ae7da2f77412731fb"
     },
     {
       "seq": "3",
-      "id": "1ee34ed8-09de-455d-9c3d-d3874cd6adb0",
+      "id": "99f2e17a-433f-4b10-bde3-63cab6f6ce8b",
       "occurred_at": "2026-06-12T09:32:00.000Z",
       "actor": {
         "kind": "agent",
@@ -68,12 +68,12 @@
         "model": "claude",
         "tokens": 412
       },
-      "prev_hash": "56f146d988c8719ba781082b224e3cdec0b1cad84d502dbff4dcd44bee32394c",
-      "hash": "7c98c3ae7ad6d2ab6b75829a3c40481db262722bf04732715500c10519150e4b"
+      "prev_hash": "2b54c3b14d6a65ca7f6c017c1284fc048fd469ba82cea60ae7da2f77412731fb",
+      "hash": "015e435097136a3fa9455d4853beadff18fb3ce45d3056cccac07b9937ee44ad"
     },
     {
       "seq": "4",
-      "id": "2c9c383e-4729-4710-82e5-44bd1403f865",
+      "id": "b49c97f6-905a-4ed6-bc6c-79052df12a77",
       "occurred_at": "2026-06-12T09:33:00.000Z",
       "actor": {
         "kind": "agent",
@@ -89,12 +89,12 @@
         "at": "decision",
         "skill": "e2b-submit@1.0.0"
       },
-      "prev_hash": "7c98c3ae7ad6d2ab6b75829a3c40481db262722bf04732715500c10519150e4b",
-      "hash": "ca3c15dd6ca8e19facaacdc86f9f1e8c6b977673e1f480a787fdbc77159e4d0a"
+      "prev_hash": "015e435097136a3fa9455d4853beadff18fb3ce45d3056cccac07b9937ee44ad",
+      "hash": "9ad04a2cc71b961a1a6f8239e4d5f0b3de823736df4606f9f4e3f939bff9786c"
     },
     {
       "seq": "5",
-      "id": "39ce56bf-ef30-4d77-a74f-9bb3158da3ee",
+      "id": "31c20cde-7148-4c2c-a622-f07c5c363866",
       "occurred_at": "2026-06-12T09:34:00.000Z",
       "actor": {
         "kind": "agent",
@@ -109,12 +109,12 @@
         "gate": "medical-review",
         "skill": "e2b-submit@1.0.0"
       },
-      "prev_hash": "ca3c15dd6ca8e19facaacdc86f9f1e8c6b977673e1f480a787fdbc77159e4d0a",
-      "hash": "c39df83422f73aed594e19e40a909804c4ee480396aa0b5d71755c543549db62"
+      "prev_hash": "9ad04a2cc71b961a1a6f8239e4d5f0b3de823736df4606f9f4e3f939bff9786c",
+      "hash": "57f8a59bafeae2f826d31629862688a46c1515a147a3e62702ba0fa4565b2a25"
     },
     {
       "seq": "6",
-      "id": "9999bca3-ae59-47cf-b837-96e420358f23",
+      "id": "e4669a21-bf23-4060-a4cd-1b5d5e08bf30",
       "occurred_at": "2026-06-12T09:35:00.000Z",
       "actor": {
         "kind": "user",
@@ -130,12 +130,12 @@
         "decider": "user-0009",
         "reason": "Seriousness confirmed for P-4003; file 15-day expedited ICSR per 21 CFR 314.80"
       },
-      "prev_hash": "c39df83422f73aed594e19e40a909804c4ee480396aa0b5d71755c543549db62",
-      "hash": "2371e189d827c2a7ff0b118aa69fb617f8b3a5f5c735c551af419a356edac73a"
+      "prev_hash": "57f8a59bafeae2f826d31629862688a46c1515a147a3e62702ba0fa4565b2a25",
+      "hash": "ca3a64bd883cbec2ddf11974f9f8fca1cebb732687e5c8f8277821ddec716709"
     },
     {
       "seq": "7",
-      "id": "32ab037c-7a91-499b-b3e7-70897eb171e4",
+      "id": "cc4c6781-4f65-4a85-94d4-6f646c6525d9",
       "occurred_at": "2026-06-12T09:36:00.000Z",
       "actor": {
         "kind": "agent",
@@ -150,12 +150,12 @@
         "skill": "e2b-submit@1.0.0",
         "outcome": "filed"
       },
-      "prev_hash": "2371e189d827c2a7ff0b118aa69fb617f8b3a5f5c735c551af419a356edac73a",
-      "hash": "219870cd84785c6b0d52c671087d937e63b659325bff852f0657f418cb580131"
+      "prev_hash": "ca3a64bd883cbec2ddf11974f9f8fca1cebb732687e5c8f8277821ddec716709",
+      "hash": "1cbfd5cfada2d4a5b330f3e941c236f1ab3bd59cfba3ee9daf47eb032dd00515"
     },
     {
       "seq": "8",
-      "id": "313c0875-9cb6-4f9a-be10-448559f1316b",
+      "id": "4154b87f-6db0-468e-b406-62374019d076",
       "occurred_at": "2026-06-12T09:37:00.000Z",
       "actor": {
         "kind": "agent",
@@ -169,8 +169,8 @@
       "payload": {
         "status": "completed"
       },
-      "prev_hash": "219870cd84785c6b0d52c671087d937e63b659325bff852f0657f418cb580131",
-      "hash": "08664a25e2828506f5d943e6ae9703cb542da630c6cb0509d2c0c944638ee5b3"
+      "prev_hash": "1cbfd5cfada2d4a5b330f3e941c236f1ab3bd59cfba3ee9daf47eb032dd00515",
+      "hash": "f5ab5d1e8308b03d7bec7ff95826980559cdfcf7fbd97caa574a7110c87503f2"
     }
   ]
 }

--- a/packages/proof-verifier/vectors/truncated.json
+++ b/packages/proof-verifier/vectors/truncated.json
@@ -8,15 +8,15 @@
     "count": 8,
     "firstSeq": "1",
     "lastSeq": "8",
-    "headHash": "08664a25e2828506f5d943e6ae9703cb542da630c6cb0509d2c0c944638ee5b3",
-    "eventHashesDigest": "c66264a199f3753e0fbad03b065617154b85b87af975d50acfc1b5012c0dceb7",
-    "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMCowBQYDK2VwAyEAnKdCt10Ts7ExQIzFvO2ME06hpng7uY5F4yjtKLOXW04=\n-----END PUBLIC KEY-----\n",
-    "signature": "SopGjkctNALSUcyBobWBX9Pjtct3mud06wPRkULa7DZxJ/VoL7kTOkiGiGizbyLy0acD4uzgXryS+qP7iZZnCA=="
+    "headHash": "f5ab5d1e8308b03d7bec7ff95826980559cdfcf7fbd97caa574a7110c87503f2",
+    "eventHashesDigest": "b24e414ea6d84f067c41037513a52b1b863d3c2cf95fe0cf927ad1f8e43fc51a",
+    "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMCowBQYDK2VwAyEAtAZrcPkaCk+v8mKz+NYQhe8V3qHlMnjwG5pzpSgYa18=\n-----END PUBLIC KEY-----\n",
+    "signature": "SYl51nvfZX6ezpWBMXdItcJ45aBS1O1RoRVX+F7rctDJbKfMpALufkfwE0Mhpe5dqSuxS4DaqEW/O68MJjMXAA=="
   },
   "events": [
     {
       "seq": "1",
-      "id": "5deb576a-a2dc-4e3d-8af1-96c0e2f240e7",
+      "id": "3a9cd439-910a-436d-befd-1c0bb76fd479",
       "occurred_at": "2026-06-12T09:30:00.000Z",
       "actor": {
         "kind": "system",
@@ -30,11 +30,11 @@
         "instanceId": "11111111-1111-4111-8111-111111111111"
       },
       "prev_hash": "a3223803bd3572c34689d246ee3c15b0c385d9d092cf9c9450dff59c32bf0b30",
-      "hash": "383904a6ed018b1fb36e082a53644c803311a86fd69e86aaa048eeddf9b8dd2c"
+      "hash": "9958ab1671c49af7902ec5dbaafdcb9d8603ab3b835fb7a6926b1fcd40c53a71"
     },
     {
       "seq": "2",
-      "id": "ae6557d9-6ceb-472c-9df2-40c594df28b3",
+      "id": "a3bf4c66-cf44-4254-a2b6-df5ce312a3cf",
       "occurred_at": "2026-06-12T09:31:00.000Z",
       "actor": {
         "kind": "agent",
@@ -48,12 +48,12 @@
       "payload": {
         "flow": "pv-icsr-processing"
       },
-      "prev_hash": "383904a6ed018b1fb36e082a53644c803311a86fd69e86aaa048eeddf9b8dd2c",
-      "hash": "56f146d988c8719ba781082b224e3cdec0b1cad84d502dbff4dcd44bee32394c"
+      "prev_hash": "9958ab1671c49af7902ec5dbaafdcb9d8603ab3b835fb7a6926b1fcd40c53a71",
+      "hash": "2b54c3b14d6a65ca7f6c017c1284fc048fd469ba82cea60ae7da2f77412731fb"
     },
     {
       "seq": "3",
-      "id": "1ee34ed8-09de-455d-9c3d-d3874cd6adb0",
+      "id": "99f2e17a-433f-4b10-bde3-63cab6f6ce8b",
       "occurred_at": "2026-06-12T09:32:00.000Z",
       "actor": {
         "kind": "agent",
@@ -68,12 +68,12 @@
         "model": "claude",
         "tokens": 412
       },
-      "prev_hash": "56f146d988c8719ba781082b224e3cdec0b1cad84d502dbff4dcd44bee32394c",
-      "hash": "7c98c3ae7ad6d2ab6b75829a3c40481db262722bf04732715500c10519150e4b"
+      "prev_hash": "2b54c3b14d6a65ca7f6c017c1284fc048fd469ba82cea60ae7da2f77412731fb",
+      "hash": "015e435097136a3fa9455d4853beadff18fb3ce45d3056cccac07b9937ee44ad"
     },
     {
       "seq": "4",
-      "id": "2c9c383e-4729-4710-82e5-44bd1403f865",
+      "id": "b49c97f6-905a-4ed6-bc6c-79052df12a77",
       "occurred_at": "2026-06-12T09:33:00.000Z",
       "actor": {
         "kind": "agent",
@@ -89,12 +89,12 @@
         "at": "decision",
         "skill": "e2b-submit@1.0.0"
       },
-      "prev_hash": "7c98c3ae7ad6d2ab6b75829a3c40481db262722bf04732715500c10519150e4b",
-      "hash": "ca3c15dd6ca8e19facaacdc86f9f1e8c6b977673e1f480a787fdbc77159e4d0a"
+      "prev_hash": "015e435097136a3fa9455d4853beadff18fb3ce45d3056cccac07b9937ee44ad",
+      "hash": "9ad04a2cc71b961a1a6f8239e4d5f0b3de823736df4606f9f4e3f939bff9786c"
     },
     {
       "seq": "5",
-      "id": "39ce56bf-ef30-4d77-a74f-9bb3158da3ee",
+      "id": "31c20cde-7148-4c2c-a622-f07c5c363866",
       "occurred_at": "2026-06-12T09:34:00.000Z",
       "actor": {
         "kind": "agent",
@@ -109,12 +109,12 @@
         "gate": "medical-review",
         "skill": "e2b-submit@1.0.0"
       },
-      "prev_hash": "ca3c15dd6ca8e19facaacdc86f9f1e8c6b977673e1f480a787fdbc77159e4d0a",
-      "hash": "c39df83422f73aed594e19e40a909804c4ee480396aa0b5d71755c543549db62"
+      "prev_hash": "9ad04a2cc71b961a1a6f8239e4d5f0b3de823736df4606f9f4e3f939bff9786c",
+      "hash": "57f8a59bafeae2f826d31629862688a46c1515a147a3e62702ba0fa4565b2a25"
     },
     {
       "seq": "6",
-      "id": "9999bca3-ae59-47cf-b837-96e420358f23",
+      "id": "e4669a21-bf23-4060-a4cd-1b5d5e08bf30",
       "occurred_at": "2026-06-12T09:35:00.000Z",
       "actor": {
         "kind": "user",
@@ -130,12 +130,12 @@
         "decider": "user-0009",
         "reason": "Seriousness confirmed for P-4003; file 15-day expedited ICSR per 21 CFR 314.80"
       },
-      "prev_hash": "c39df83422f73aed594e19e40a909804c4ee480396aa0b5d71755c543549db62",
-      "hash": "2371e189d827c2a7ff0b118aa69fb617f8b3a5f5c735c551af419a356edac73a"
+      "prev_hash": "57f8a59bafeae2f826d31629862688a46c1515a147a3e62702ba0fa4565b2a25",
+      "hash": "ca3a64bd883cbec2ddf11974f9f8fca1cebb732687e5c8f8277821ddec716709"
     },
     {
       "seq": "7",
-      "id": "32ab037c-7a91-499b-b3e7-70897eb171e4",
+      "id": "cc4c6781-4f65-4a85-94d4-6f646c6525d9",
       "occurred_at": "2026-06-12T09:36:00.000Z",
       "actor": {
         "kind": "agent",
@@ -150,8 +150,8 @@
         "skill": "e2b-submit@1.0.0",
         "outcome": "filed"
       },
-      "prev_hash": "2371e189d827c2a7ff0b118aa69fb617f8b3a5f5c735c551af419a356edac73a",
-      "hash": "219870cd84785c6b0d52c671087d937e63b659325bff852f0657f418cb580131"
+      "prev_hash": "ca3a64bd883cbec2ddf11974f9f8fca1cebb732687e5c8f8277821ddec716709",
+      "hash": "1cbfd5cfada2d4a5b330f3e941c236f1ab3bd59cfba3ee9daf47eb032dd00515"
     }
   ]
 }

--- a/packages/proof-verifier/vectors/unicode-literal.json
+++ b/packages/proof-verifier/vectors/unicode-literal.json
@@ -1,19 +1,37 @@
 {
   "manifest": {
-    "bundleKind": "run",
+    "bundleKind": "full",
     "schemaVersion": 1,
     "instanceId": "11111111-1111-4111-8111-111111111111",
     "exportedAt": "2026-06-12T10:00:00.000Z",
-    "runId": "22222222-2222-4222-8222-222222222222",
-    "count": 8,
-    "firstSeq": "2",
-    "lastSeq": "8",
-    "headHash": "f5ab5d1e8308b03d7bec7ff95826980559cdfcf7fbd97caa574a7110c87503f2",
-    "eventHashesDigest": "63f8ea885390881348d5752fa62a40ef527aa45f8d9639f4ecd9796a212e7d86",
+    "runId": null,
+    "count": 9,
+    "firstSeq": "1",
+    "lastSeq": "9",
+    "headHash": "fb01493b318206320b84c099d2266e8ad7085f596b80d935c8445a96ff7d0a4b",
+    "eventHashesDigest": "3205e98a3a3255d5795d41741c67ee0bb6431ae3684853712e177d468a171a5e",
     "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMCowBQYDK2VwAyEAtAZrcPkaCk+v8mKz+NYQhe8V3qHlMnjwG5pzpSgYa18=\n-----END PUBLIC KEY-----\n",
-    "signature": "YDPVk6k9KYp1O7GsZ33lPYt5n4atgSrHwlBh2OAWjCQEGvD9Al9Nmg18pjO3WVCJmZukUsalBpgFzNLwwux4Ag=="
+    "signature": "ri4+quLn/jxo7y5wH3kpuvgjxUrTU0oAslvpYnNvDYMIRpgvDYVTUcmwWYB7PyBwqPvlv75JDKkIZEzXEgFxCQ=="
   },
   "events": [
+    {
+      "seq": "1",
+      "id": "3a9cd439-910a-436d-befd-1c0bb76fd479",
+      "occurred_at": "2026-06-12T09:30:00.000Z",
+      "actor": {
+        "kind": "system",
+        "id": "instance"
+      },
+      "event_type": "audit.genesis",
+      "entity_type": null,
+      "entity_id": null,
+      "run_id": null,
+      "payload": {
+        "instanceId": "11111111-1111-4111-8111-111111111111"
+      },
+      "prev_hash": "a3223803bd3572c34689d246ee3c15b0c385d9d092cf9c9450dff59c32bf0b30",
+      "hash": "9958ab1671c49af7902ec5dbaafdcb9d8603ab3b835fb7a6926b1fcd40c53a71"
+    },
     {
       "seq": "2",
       "id": "a3bf4c66-cf44-4254-a2b6-df5ce312a3cf",
@@ -73,25 +91,6 @@
       },
       "prev_hash": "015e435097136a3fa9455d4853beadff18fb3ce45d3056cccac07b9937ee44ad",
       "hash": "9ad04a2cc71b961a1a6f8239e4d5f0b3de823736df4606f9f4e3f939bff9786c"
-    },
-    {
-      "seq": "99",
-      "entity_type": null,
-      "entity_id": null,
-      "prev_hash": "9ad04a2cc71b961a1a6f8239e4d5f0b3de823736df4606f9f4e3f939bff9786c",
-      "id": "b498dd93-a24d-4732-9549-07ad6f9d7bc2",
-      "occurred_at": "2026-06-12T09:35:00.000Z",
-      "actor": {
-        "kind": "agent",
-        "id": "agent-0001",
-        "role": "case-processor"
-      },
-      "event_type": "skill.invoked",
-      "run_id": "33333333-3333-4333-8333-333333333333",
-      "payload": {
-        "skill": "x"
-      },
-      "hash": "d00563cb81c80b3bd87e83ec463ce284e8b73333cdcaf55f6778f72e9d9a4100"
     },
     {
       "seq": "5",
@@ -172,6 +171,27 @@
       },
       "prev_hash": "1cbfd5cfada2d4a5b330f3e941c236f1ab3bd59cfba3ee9daf47eb032dd00515",
       "hash": "f5ab5d1e8308b03d7bec7ff95826980559cdfcf7fbd97caa574a7110c87503f2"
+    },
+    {
+      "seq": "9",
+      "id": "1e3374b2-b337-4354-a949-61dbf6189da9",
+      "occurred_at": "2026-06-12T09:38:00.000Z",
+      "actor": {
+        "kind": "agent",
+        "id": "agent-0001",
+        "role": "case-processor"
+      },
+      "event_type": "note.recorded",
+      "entity_type": null,
+      "entity_id": null,
+      "run_id": "22222222-2222-4222-8222-222222222222",
+      "payload": {
+        "emoji": "😀",
+        "nfc": "é",
+        "nfd": "é"
+      },
+      "prev_hash": "f5ab5d1e8308b03d7bec7ff95826980559cdfcf7fbd97caa574a7110c87503f2",
+      "hash": "fb01493b318206320b84c099d2266e8ad7085f596b80d935c8445a96ff7d0a4b"
     }
   ]
 }

--- a/packages/proof-verifier/vectors/valid-full.json
+++ b/packages/proof-verifier/vectors/valid-full.json
@@ -8,15 +8,15 @@
     "count": 8,
     "firstSeq": "1",
     "lastSeq": "8",
-    "headHash": "08664a25e2828506f5d943e6ae9703cb542da630c6cb0509d2c0c944638ee5b3",
-    "eventHashesDigest": "c66264a199f3753e0fbad03b065617154b85b87af975d50acfc1b5012c0dceb7",
-    "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMCowBQYDK2VwAyEAnKdCt10Ts7ExQIzFvO2ME06hpng7uY5F4yjtKLOXW04=\n-----END PUBLIC KEY-----\n",
-    "signature": "SopGjkctNALSUcyBobWBX9Pjtct3mud06wPRkULa7DZxJ/VoL7kTOkiGiGizbyLy0acD4uzgXryS+qP7iZZnCA=="
+    "headHash": "f5ab5d1e8308b03d7bec7ff95826980559cdfcf7fbd97caa574a7110c87503f2",
+    "eventHashesDigest": "b24e414ea6d84f067c41037513a52b1b863d3c2cf95fe0cf927ad1f8e43fc51a",
+    "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMCowBQYDK2VwAyEAtAZrcPkaCk+v8mKz+NYQhe8V3qHlMnjwG5pzpSgYa18=\n-----END PUBLIC KEY-----\n",
+    "signature": "SYl51nvfZX6ezpWBMXdItcJ45aBS1O1RoRVX+F7rctDJbKfMpALufkfwE0Mhpe5dqSuxS4DaqEW/O68MJjMXAA=="
   },
   "events": [
     {
       "seq": "1",
-      "id": "5deb576a-a2dc-4e3d-8af1-96c0e2f240e7",
+      "id": "3a9cd439-910a-436d-befd-1c0bb76fd479",
       "occurred_at": "2026-06-12T09:30:00.000Z",
       "actor": {
         "kind": "system",
@@ -30,11 +30,11 @@
         "instanceId": "11111111-1111-4111-8111-111111111111"
       },
       "prev_hash": "a3223803bd3572c34689d246ee3c15b0c385d9d092cf9c9450dff59c32bf0b30",
-      "hash": "383904a6ed018b1fb36e082a53644c803311a86fd69e86aaa048eeddf9b8dd2c"
+      "hash": "9958ab1671c49af7902ec5dbaafdcb9d8603ab3b835fb7a6926b1fcd40c53a71"
     },
     {
       "seq": "2",
-      "id": "ae6557d9-6ceb-472c-9df2-40c594df28b3",
+      "id": "a3bf4c66-cf44-4254-a2b6-df5ce312a3cf",
       "occurred_at": "2026-06-12T09:31:00.000Z",
       "actor": {
         "kind": "agent",
@@ -48,12 +48,12 @@
       "payload": {
         "flow": "pv-icsr-processing"
       },
-      "prev_hash": "383904a6ed018b1fb36e082a53644c803311a86fd69e86aaa048eeddf9b8dd2c",
-      "hash": "56f146d988c8719ba781082b224e3cdec0b1cad84d502dbff4dcd44bee32394c"
+      "prev_hash": "9958ab1671c49af7902ec5dbaafdcb9d8603ab3b835fb7a6926b1fcd40c53a71",
+      "hash": "2b54c3b14d6a65ca7f6c017c1284fc048fd469ba82cea60ae7da2f77412731fb"
     },
     {
       "seq": "3",
-      "id": "1ee34ed8-09de-455d-9c3d-d3874cd6adb0",
+      "id": "99f2e17a-433f-4b10-bde3-63cab6f6ce8b",
       "occurred_at": "2026-06-12T09:32:00.000Z",
       "actor": {
         "kind": "agent",
@@ -68,12 +68,12 @@
         "model": "claude",
         "tokens": 412
       },
-      "prev_hash": "56f146d988c8719ba781082b224e3cdec0b1cad84d502dbff4dcd44bee32394c",
-      "hash": "7c98c3ae7ad6d2ab6b75829a3c40481db262722bf04732715500c10519150e4b"
+      "prev_hash": "2b54c3b14d6a65ca7f6c017c1284fc048fd469ba82cea60ae7da2f77412731fb",
+      "hash": "015e435097136a3fa9455d4853beadff18fb3ce45d3056cccac07b9937ee44ad"
     },
     {
       "seq": "4",
-      "id": "2c9c383e-4729-4710-82e5-44bd1403f865",
+      "id": "b49c97f6-905a-4ed6-bc6c-79052df12a77",
       "occurred_at": "2026-06-12T09:33:00.000Z",
       "actor": {
         "kind": "agent",
@@ -89,12 +89,12 @@
         "at": "decision",
         "skill": "e2b-submit@1.0.0"
       },
-      "prev_hash": "7c98c3ae7ad6d2ab6b75829a3c40481db262722bf04732715500c10519150e4b",
-      "hash": "ca3c15dd6ca8e19facaacdc86f9f1e8c6b977673e1f480a787fdbc77159e4d0a"
+      "prev_hash": "015e435097136a3fa9455d4853beadff18fb3ce45d3056cccac07b9937ee44ad",
+      "hash": "9ad04a2cc71b961a1a6f8239e4d5f0b3de823736df4606f9f4e3f939bff9786c"
     },
     {
       "seq": "5",
-      "id": "39ce56bf-ef30-4d77-a74f-9bb3158da3ee",
+      "id": "31c20cde-7148-4c2c-a622-f07c5c363866",
       "occurred_at": "2026-06-12T09:34:00.000Z",
       "actor": {
         "kind": "agent",
@@ -109,12 +109,12 @@
         "gate": "medical-review",
         "skill": "e2b-submit@1.0.0"
       },
-      "prev_hash": "ca3c15dd6ca8e19facaacdc86f9f1e8c6b977673e1f480a787fdbc77159e4d0a",
-      "hash": "c39df83422f73aed594e19e40a909804c4ee480396aa0b5d71755c543549db62"
+      "prev_hash": "9ad04a2cc71b961a1a6f8239e4d5f0b3de823736df4606f9f4e3f939bff9786c",
+      "hash": "57f8a59bafeae2f826d31629862688a46c1515a147a3e62702ba0fa4565b2a25"
     },
     {
       "seq": "6",
-      "id": "9999bca3-ae59-47cf-b837-96e420358f23",
+      "id": "e4669a21-bf23-4060-a4cd-1b5d5e08bf30",
       "occurred_at": "2026-06-12T09:35:00.000Z",
       "actor": {
         "kind": "user",
@@ -130,12 +130,12 @@
         "decider": "user-0009",
         "reason": "Seriousness confirmed for P-4003; file 15-day expedited ICSR per 21 CFR 314.80"
       },
-      "prev_hash": "c39df83422f73aed594e19e40a909804c4ee480396aa0b5d71755c543549db62",
-      "hash": "2371e189d827c2a7ff0b118aa69fb617f8b3a5f5c735c551af419a356edac73a"
+      "prev_hash": "57f8a59bafeae2f826d31629862688a46c1515a147a3e62702ba0fa4565b2a25",
+      "hash": "ca3a64bd883cbec2ddf11974f9f8fca1cebb732687e5c8f8277821ddec716709"
     },
     {
       "seq": "7",
-      "id": "32ab037c-7a91-499b-b3e7-70897eb171e4",
+      "id": "cc4c6781-4f65-4a85-94d4-6f646c6525d9",
       "occurred_at": "2026-06-12T09:36:00.000Z",
       "actor": {
         "kind": "agent",
@@ -150,12 +150,12 @@
         "skill": "e2b-submit@1.0.0",
         "outcome": "filed"
       },
-      "prev_hash": "2371e189d827c2a7ff0b118aa69fb617f8b3a5f5c735c551af419a356edac73a",
-      "hash": "219870cd84785c6b0d52c671087d937e63b659325bff852f0657f418cb580131"
+      "prev_hash": "ca3a64bd883cbec2ddf11974f9f8fca1cebb732687e5c8f8277821ddec716709",
+      "hash": "1cbfd5cfada2d4a5b330f3e941c236f1ab3bd59cfba3ee9daf47eb032dd00515"
     },
     {
       "seq": "8",
-      "id": "313c0875-9cb6-4f9a-be10-448559f1316b",
+      "id": "4154b87f-6db0-468e-b406-62374019d076",
       "occurred_at": "2026-06-12T09:37:00.000Z",
       "actor": {
         "kind": "agent",
@@ -169,8 +169,8 @@
       "payload": {
         "status": "completed"
       },
-      "prev_hash": "219870cd84785c6b0d52c671087d937e63b659325bff852f0657f418cb580131",
-      "hash": "08664a25e2828506f5d943e6ae9703cb542da630c6cb0509d2c0c944638ee5b3"
+      "prev_hash": "1cbfd5cfada2d4a5b330f3e941c236f1ab3bd59cfba3ee9daf47eb032dd00515",
+      "hash": "f5ab5d1e8308b03d7bec7ff95826980559cdfcf7fbd97caa574a7110c87503f2"
     }
   ]
 }

--- a/packages/proof-verifier/vectors/valid-run.json
+++ b/packages/proof-verifier/vectors/valid-run.json
@@ -8,15 +8,15 @@
     "count": 7,
     "firstSeq": "2",
     "lastSeq": "8",
-    "headHash": "08664a25e2828506f5d943e6ae9703cb542da630c6cb0509d2c0c944638ee5b3",
-    "eventHashesDigest": "d1f5fba0db15defa1f10f84f30dfdd52169a88766cb51d53f5aa4a4e8f3d3c7c",
-    "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMCowBQYDK2VwAyEAnKdCt10Ts7ExQIzFvO2ME06hpng7uY5F4yjtKLOXW04=\n-----END PUBLIC KEY-----\n",
-    "signature": "ROo12y6kBuqvcoE9xeHejBPCuN8h0N1FYhB2dbRyfwaWJ1g0vlTdorbeXVnI9kR++Ib5cTselLqEDOnkoQ5gBw=="
+    "headHash": "f5ab5d1e8308b03d7bec7ff95826980559cdfcf7fbd97caa574a7110c87503f2",
+    "eventHashesDigest": "25b89dbe47730480817b52a0419daf0948a12bb4d2620f10f25711e46ba2ba0d",
+    "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMCowBQYDK2VwAyEAtAZrcPkaCk+v8mKz+NYQhe8V3qHlMnjwG5pzpSgYa18=\n-----END PUBLIC KEY-----\n",
+    "signature": "TKZPjnmEid2ORK1n0GG7XTEv61t1mzsq4zd7iSe+p7suiD8VmaHdr0LGY/c9+WeEahJaw5KzMdv5L8pO1OyfAw=="
   },
   "events": [
     {
       "seq": "2",
-      "id": "ae6557d9-6ceb-472c-9df2-40c594df28b3",
+      "id": "a3bf4c66-cf44-4254-a2b6-df5ce312a3cf",
       "occurred_at": "2026-06-12T09:31:00.000Z",
       "actor": {
         "kind": "agent",
@@ -30,12 +30,12 @@
       "payload": {
         "flow": "pv-icsr-processing"
       },
-      "prev_hash": "383904a6ed018b1fb36e082a53644c803311a86fd69e86aaa048eeddf9b8dd2c",
-      "hash": "56f146d988c8719ba781082b224e3cdec0b1cad84d502dbff4dcd44bee32394c"
+      "prev_hash": "9958ab1671c49af7902ec5dbaafdcb9d8603ab3b835fb7a6926b1fcd40c53a71",
+      "hash": "2b54c3b14d6a65ca7f6c017c1284fc048fd469ba82cea60ae7da2f77412731fb"
     },
     {
       "seq": "3",
-      "id": "1ee34ed8-09de-455d-9c3d-d3874cd6adb0",
+      "id": "99f2e17a-433f-4b10-bde3-63cab6f6ce8b",
       "occurred_at": "2026-06-12T09:32:00.000Z",
       "actor": {
         "kind": "agent",
@@ -50,12 +50,12 @@
         "model": "claude",
         "tokens": 412
       },
-      "prev_hash": "56f146d988c8719ba781082b224e3cdec0b1cad84d502dbff4dcd44bee32394c",
-      "hash": "7c98c3ae7ad6d2ab6b75829a3c40481db262722bf04732715500c10519150e4b"
+      "prev_hash": "2b54c3b14d6a65ca7f6c017c1284fc048fd469ba82cea60ae7da2f77412731fb",
+      "hash": "015e435097136a3fa9455d4853beadff18fb3ce45d3056cccac07b9937ee44ad"
     },
     {
       "seq": "4",
-      "id": "2c9c383e-4729-4710-82e5-44bd1403f865",
+      "id": "b49c97f6-905a-4ed6-bc6c-79052df12a77",
       "occurred_at": "2026-06-12T09:33:00.000Z",
       "actor": {
         "kind": "agent",
@@ -71,12 +71,12 @@
         "at": "decision",
         "skill": "e2b-submit@1.0.0"
       },
-      "prev_hash": "7c98c3ae7ad6d2ab6b75829a3c40481db262722bf04732715500c10519150e4b",
-      "hash": "ca3c15dd6ca8e19facaacdc86f9f1e8c6b977673e1f480a787fdbc77159e4d0a"
+      "prev_hash": "015e435097136a3fa9455d4853beadff18fb3ce45d3056cccac07b9937ee44ad",
+      "hash": "9ad04a2cc71b961a1a6f8239e4d5f0b3de823736df4606f9f4e3f939bff9786c"
     },
     {
       "seq": "5",
-      "id": "39ce56bf-ef30-4d77-a74f-9bb3158da3ee",
+      "id": "31c20cde-7148-4c2c-a622-f07c5c363866",
       "occurred_at": "2026-06-12T09:34:00.000Z",
       "actor": {
         "kind": "agent",
@@ -91,12 +91,12 @@
         "gate": "medical-review",
         "skill": "e2b-submit@1.0.0"
       },
-      "prev_hash": "ca3c15dd6ca8e19facaacdc86f9f1e8c6b977673e1f480a787fdbc77159e4d0a",
-      "hash": "c39df83422f73aed594e19e40a909804c4ee480396aa0b5d71755c543549db62"
+      "prev_hash": "9ad04a2cc71b961a1a6f8239e4d5f0b3de823736df4606f9f4e3f939bff9786c",
+      "hash": "57f8a59bafeae2f826d31629862688a46c1515a147a3e62702ba0fa4565b2a25"
     },
     {
       "seq": "6",
-      "id": "9999bca3-ae59-47cf-b837-96e420358f23",
+      "id": "e4669a21-bf23-4060-a4cd-1b5d5e08bf30",
       "occurred_at": "2026-06-12T09:35:00.000Z",
       "actor": {
         "kind": "user",
@@ -112,12 +112,12 @@
         "decider": "user-0009",
         "reason": "Seriousness confirmed for P-4003; file 15-day expedited ICSR per 21 CFR 314.80"
       },
-      "prev_hash": "c39df83422f73aed594e19e40a909804c4ee480396aa0b5d71755c543549db62",
-      "hash": "2371e189d827c2a7ff0b118aa69fb617f8b3a5f5c735c551af419a356edac73a"
+      "prev_hash": "57f8a59bafeae2f826d31629862688a46c1515a147a3e62702ba0fa4565b2a25",
+      "hash": "ca3a64bd883cbec2ddf11974f9f8fca1cebb732687e5c8f8277821ddec716709"
     },
     {
       "seq": "7",
-      "id": "32ab037c-7a91-499b-b3e7-70897eb171e4",
+      "id": "cc4c6781-4f65-4a85-94d4-6f646c6525d9",
       "occurred_at": "2026-06-12T09:36:00.000Z",
       "actor": {
         "kind": "agent",
@@ -132,12 +132,12 @@
         "skill": "e2b-submit@1.0.0",
         "outcome": "filed"
       },
-      "prev_hash": "2371e189d827c2a7ff0b118aa69fb617f8b3a5f5c735c551af419a356edac73a",
-      "hash": "219870cd84785c6b0d52c671087d937e63b659325bff852f0657f418cb580131"
+      "prev_hash": "ca3a64bd883cbec2ddf11974f9f8fca1cebb732687e5c8f8277821ddec716709",
+      "hash": "1cbfd5cfada2d4a5b330f3e941c236f1ab3bd59cfba3ee9daf47eb032dd00515"
     },
     {
       "seq": "8",
-      "id": "313c0875-9cb6-4f9a-be10-448559f1316b",
+      "id": "4154b87f-6db0-468e-b406-62374019d076",
       "occurred_at": "2026-06-12T09:37:00.000Z",
       "actor": {
         "kind": "agent",
@@ -151,8 +151,8 @@
       "payload": {
         "status": "completed"
       },
-      "prev_hash": "219870cd84785c6b0d52c671087d937e63b659325bff852f0657f418cb580131",
-      "hash": "08664a25e2828506f5d943e6ae9703cb542da630c6cb0509d2c0c944638ee5b3"
+      "prev_hash": "1cbfd5cfada2d4a5b330f3e941c236f1ab3bd59cfba3ee9daf47eb032dd00515",
+      "hash": "f5ab5d1e8308b03d7bec7ff95826980559cdfcf7fbd97caa574a7110c87503f2"
     }
   ]
 }

--- a/packages/proof-verifier/vectors/wrong-key.json
+++ b/packages/proof-verifier/vectors/wrong-key.json
@@ -8,15 +8,15 @@
     "count": 8,
     "firstSeq": "1",
     "lastSeq": "8",
-    "headHash": "08664a25e2828506f5d943e6ae9703cb542da630c6cb0509d2c0c944638ee5b3",
-    "eventHashesDigest": "c66264a199f3753e0fbad03b065617154b85b87af975d50acfc1b5012c0dceb7",
-    "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMCowBQYDK2VwAyEAjc3jVqOBSTh3KYYdA/I89XEPAMExF1Oo/o/JzsJ9cCg=\n-----END PUBLIC KEY-----\n",
-    "signature": "YIJKpPKG2kDDIEg0nWErAC+FhLr7NTrHdaE/SELm+TPzsPt/8BMIxuns3JZ2LYgX1oRTV9RJFk4Ys7WkB7M0Dw=="
+    "headHash": "f5ab5d1e8308b03d7bec7ff95826980559cdfcf7fbd97caa574a7110c87503f2",
+    "eventHashesDigest": "b24e414ea6d84f067c41037513a52b1b863d3c2cf95fe0cf927ad1f8e43fc51a",
+    "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMCowBQYDK2VwAyEAMIrkoOHkkQjC+u2C1Kr7loJZXiS3L96hkz5AV3c10cg=\n-----END PUBLIC KEY-----\n",
+    "signature": "Uu4SERs/SnSQtoHAF4YvAOx/x6r73UUvFtIDsOL0VDveWEZqSTAU8E3GEbFDL5vQDejnSm+vYQMUmUAXiwdUAw=="
   },
   "events": [
     {
       "seq": "1",
-      "id": "5deb576a-a2dc-4e3d-8af1-96c0e2f240e7",
+      "id": "3a9cd439-910a-436d-befd-1c0bb76fd479",
       "occurred_at": "2026-06-12T09:30:00.000Z",
       "actor": {
         "kind": "system",
@@ -30,11 +30,11 @@
         "instanceId": "11111111-1111-4111-8111-111111111111"
       },
       "prev_hash": "a3223803bd3572c34689d246ee3c15b0c385d9d092cf9c9450dff59c32bf0b30",
-      "hash": "383904a6ed018b1fb36e082a53644c803311a86fd69e86aaa048eeddf9b8dd2c"
+      "hash": "9958ab1671c49af7902ec5dbaafdcb9d8603ab3b835fb7a6926b1fcd40c53a71"
     },
     {
       "seq": "2",
-      "id": "ae6557d9-6ceb-472c-9df2-40c594df28b3",
+      "id": "a3bf4c66-cf44-4254-a2b6-df5ce312a3cf",
       "occurred_at": "2026-06-12T09:31:00.000Z",
       "actor": {
         "kind": "agent",
@@ -48,12 +48,12 @@
       "payload": {
         "flow": "pv-icsr-processing"
       },
-      "prev_hash": "383904a6ed018b1fb36e082a53644c803311a86fd69e86aaa048eeddf9b8dd2c",
-      "hash": "56f146d988c8719ba781082b224e3cdec0b1cad84d502dbff4dcd44bee32394c"
+      "prev_hash": "9958ab1671c49af7902ec5dbaafdcb9d8603ab3b835fb7a6926b1fcd40c53a71",
+      "hash": "2b54c3b14d6a65ca7f6c017c1284fc048fd469ba82cea60ae7da2f77412731fb"
     },
     {
       "seq": "3",
-      "id": "1ee34ed8-09de-455d-9c3d-d3874cd6adb0",
+      "id": "99f2e17a-433f-4b10-bde3-63cab6f6ce8b",
       "occurred_at": "2026-06-12T09:32:00.000Z",
       "actor": {
         "kind": "agent",
@@ -68,12 +68,12 @@
         "model": "claude",
         "tokens": 412
       },
-      "prev_hash": "56f146d988c8719ba781082b224e3cdec0b1cad84d502dbff4dcd44bee32394c",
-      "hash": "7c98c3ae7ad6d2ab6b75829a3c40481db262722bf04732715500c10519150e4b"
+      "prev_hash": "2b54c3b14d6a65ca7f6c017c1284fc048fd469ba82cea60ae7da2f77412731fb",
+      "hash": "015e435097136a3fa9455d4853beadff18fb3ce45d3056cccac07b9937ee44ad"
     },
     {
       "seq": "4",
-      "id": "2c9c383e-4729-4710-82e5-44bd1403f865",
+      "id": "b49c97f6-905a-4ed6-bc6c-79052df12a77",
       "occurred_at": "2026-06-12T09:33:00.000Z",
       "actor": {
         "kind": "agent",
@@ -89,12 +89,12 @@
         "at": "decision",
         "skill": "e2b-submit@1.0.0"
       },
-      "prev_hash": "7c98c3ae7ad6d2ab6b75829a3c40481db262722bf04732715500c10519150e4b",
-      "hash": "ca3c15dd6ca8e19facaacdc86f9f1e8c6b977673e1f480a787fdbc77159e4d0a"
+      "prev_hash": "015e435097136a3fa9455d4853beadff18fb3ce45d3056cccac07b9937ee44ad",
+      "hash": "9ad04a2cc71b961a1a6f8239e4d5f0b3de823736df4606f9f4e3f939bff9786c"
     },
     {
       "seq": "5",
-      "id": "39ce56bf-ef30-4d77-a74f-9bb3158da3ee",
+      "id": "31c20cde-7148-4c2c-a622-f07c5c363866",
       "occurred_at": "2026-06-12T09:34:00.000Z",
       "actor": {
         "kind": "agent",
@@ -109,12 +109,12 @@
         "gate": "medical-review",
         "skill": "e2b-submit@1.0.0"
       },
-      "prev_hash": "ca3c15dd6ca8e19facaacdc86f9f1e8c6b977673e1f480a787fdbc77159e4d0a",
-      "hash": "c39df83422f73aed594e19e40a909804c4ee480396aa0b5d71755c543549db62"
+      "prev_hash": "9ad04a2cc71b961a1a6f8239e4d5f0b3de823736df4606f9f4e3f939bff9786c",
+      "hash": "57f8a59bafeae2f826d31629862688a46c1515a147a3e62702ba0fa4565b2a25"
     },
     {
       "seq": "6",
-      "id": "9999bca3-ae59-47cf-b837-96e420358f23",
+      "id": "e4669a21-bf23-4060-a4cd-1b5d5e08bf30",
       "occurred_at": "2026-06-12T09:35:00.000Z",
       "actor": {
         "kind": "user",
@@ -130,12 +130,12 @@
         "decider": "user-0009",
         "reason": "Seriousness confirmed for P-4003; file 15-day expedited ICSR per 21 CFR 314.80"
       },
-      "prev_hash": "c39df83422f73aed594e19e40a909804c4ee480396aa0b5d71755c543549db62",
-      "hash": "2371e189d827c2a7ff0b118aa69fb617f8b3a5f5c735c551af419a356edac73a"
+      "prev_hash": "57f8a59bafeae2f826d31629862688a46c1515a147a3e62702ba0fa4565b2a25",
+      "hash": "ca3a64bd883cbec2ddf11974f9f8fca1cebb732687e5c8f8277821ddec716709"
     },
     {
       "seq": "7",
-      "id": "32ab037c-7a91-499b-b3e7-70897eb171e4",
+      "id": "cc4c6781-4f65-4a85-94d4-6f646c6525d9",
       "occurred_at": "2026-06-12T09:36:00.000Z",
       "actor": {
         "kind": "agent",
@@ -150,12 +150,12 @@
         "skill": "e2b-submit@1.0.0",
         "outcome": "filed"
       },
-      "prev_hash": "2371e189d827c2a7ff0b118aa69fb617f8b3a5f5c735c551af419a356edac73a",
-      "hash": "219870cd84785c6b0d52c671087d937e63b659325bff852f0657f418cb580131"
+      "prev_hash": "ca3a64bd883cbec2ddf11974f9f8fca1cebb732687e5c8f8277821ddec716709",
+      "hash": "1cbfd5cfada2d4a5b330f3e941c236f1ab3bd59cfba3ee9daf47eb032dd00515"
     },
     {
       "seq": "8",
-      "id": "313c0875-9cb6-4f9a-be10-448559f1316b",
+      "id": "4154b87f-6db0-468e-b406-62374019d076",
       "occurred_at": "2026-06-12T09:37:00.000Z",
       "actor": {
         "kind": "agent",
@@ -169,8 +169,8 @@
       "payload": {
         "status": "completed"
       },
-      "prev_hash": "219870cd84785c6b0d52c671087d937e63b659325bff852f0657f418cb580131",
-      "hash": "08664a25e2828506f5d943e6ae9703cb542da630c6cb0509d2c0c944638ee5b3"
+      "prev_hash": "1cbfd5cfada2d4a5b330f3e941c236f1ab3bd59cfba3ee9daf47eb032dd00515",
+      "hash": "f5ab5d1e8308b03d7bec7ff95826980559cdfcf7fbd97caa574a7110c87503f2"
     }
   ]
 }

--- a/packages/proof-verifier/verifier.html
+++ b/packages/proof-verifier/verifier.html
@@ -73,19 +73,45 @@
 
 <script type="module">
 // ---- vendored RFC 8785 canonical JSON (identical to the producer's serializer) ----
+// Input must be I-JSON (RFC 7493): an unpaired surrogate has no interoperable
+// RFC 8785 serialization, so it is rejected (fail closed) before hashing.
+class IllFormedStringError extends Error {
+  constructor(path) {
+    super("ill-formed Unicode (unpaired surrogate) in string at " + path);
+    this.name = "IllFormedStringError";
+    this.path = path;
+  }
+}
+// String.prototype.isWellFormed exists in all modern browsers; the scan is the
+// same fallback the Node packages use, kept for older engines.
+const nativeIsWellFormed = String.prototype.isWellFormed;
+function isWellFormedString(s) {
+  if (nativeIsWellFormed) return nativeIsWellFormed.call(s);
+  for (let i = 0; i < s.length; i += 1) {
+    const unit = s.charCodeAt(i);
+    if (unit >= 0xdc00 && unit <= 0xdfff) return false;
+    if (unit >= 0xd800 && unit <= 0xdbff) {
+      const next = i + 1 < s.length ? s.charCodeAt(i + 1) : -1;
+      if (next < 0xdc00 || next > 0xdfff) return false;
+      i += 1;
+    }
+  }
+  return true;
+}
+function assertWellFormed(s, path) { if (!isWellFormedString(s)) throw new IllFormedStringError(path); }
 function canonicalJson(value) { return ser(value, "$"); }
 function ser(v, path) {
   if (v === null) return "null";
   const t = typeof v;
   if (t === "boolean") return v ? "true" : "false";
   if (t === "number") { if (!Number.isFinite(v)) throw new Error("non-finite number at " + path); return JSON.stringify(v); }
-  if (t === "string") return JSON.stringify(v);
+  if (t === "string") { assertWellFormed(v, path); return JSON.stringify(v); }
   if (t !== "object") throw new Error('unsupported type "' + t + '" at ' + path);
   if (Array.isArray(v)) return "[" + v.map((x, i) => ser(x === undefined ? null : x, path + "[" + i + "]")).join(",") + "]";
   const proto = Object.getPrototypeOf(v);
   if (proto !== Object.prototype && proto !== null) throw new Error("non-plain object at " + path);
   const keys = Object.keys(v).filter((k) => v[k] !== undefined).sort();
-  return "{" + keys.map((k) => JSON.stringify(k) + ":" + ser(v[k], path + "." + k)).join(",") + "}";
+  return "{" + keys.map((k) => { assertWellFormed(k, path + "." + k); return JSON.stringify(k) + ":" + ser(v[k], path + "." + k); }).join(",") + "}";
 }
 
 // ---- WebCrypto provider ----
@@ -136,7 +162,14 @@ async function verifyBundle(bundle, cp, opts = {}) {
   const { manifest, events } = bundle;
   if (opts.expectedPublicKeyPem && !(await cp.samePublicKeyPem(opts.expectedPublicKeyPem, manifest.publicKeyPem)))
     return fail("manifest public key does not match the pinned key");
-  if (!(await cp.ed25519Verify(manifest.publicKeyPem, manifestSigningString(manifest), manifest.signature)))
+  let signingString;
+  try { signingString = manifestSigningString(manifest); } catch (err) {
+    if (err instanceof IllFormedStringError)
+      return fail(`manifest contains an ill-formed string (unpaired surrogate) at ${err.path}: the spec requires I-JSON (RFC 7493) input, so this bundle can never cross-verify`,
+        { reasonCode: "ill_formed_string", path: err.path });
+    throw err;
+  }
+  if (!(await cp.ed25519Verify(manifest.publicKeyPem, signingString, manifest.signature)))
     return fail("manifest signature invalid");
   if (events.length !== manifest.count) return fail(`event count ${events.length} != manifest count ${manifest.count}`);
   if ((await cp.sha256Hex(events.map((e) => e.hash).join("\n"))) !== manifest.eventHashesDigest)
@@ -148,7 +181,15 @@ async function verifyBundle(bundle, cp, opts = {}) {
   } else if (manifest.bundleKind !== "full") return fail(`unknown bundleKind "${manifest.bundleKind}"`);
   let prev = manifest.bundleKind === "full" ? await cp.sha256Hex(GENESIS_PREFIX + manifest.instanceId) : null;
   for (const e of events) {
-    if ((await cp.sha256Hex(canonicalJson(hashInput(e)))) !== e.hash)
+    let recomputed;
+    try { recomputed = await cp.sha256Hex(canonicalJson(hashInput(e))); } catch (err) {
+      if (err instanceof IllFormedStringError)
+        // Spec-violation verdict (I-JSON / RFC 7493), deliberately distinct from tamper.
+        return fail(`event seq ${e.seq} contains an ill-formed string (unpaired surrogate) at ${err.path}: the spec requires I-JSON (RFC 7493) input, so this bundle can never cross-verify`,
+          { reasonCode: "ill_formed_string", failedSeq: e.seq, path: err.path });
+      throw err;
+    }
+    if (recomputed !== e.hash)
       return fail(`event seq ${e.seq} hash mismatch (row tampered)`, { failedSeq: e.seq });
     if (prev !== null) { if (e.prev_hash !== prev) return fail(`event seq ${e.seq} breaks chain linkage`, { failedSeq: e.seq }); prev = e.hash; }
   }


### PR DESCRIPTION
## What changed

Stacks onto #65 (`feat/proof-verifier`). Ports the fail-closed I-JSON (RFC 7493) check from the producer fix (#77) into the standalone verifier with identical semantics, per the external review on PR #66 by @babyblueviper1:

- **`src/canonical-json.js`** — identical, line-for-line-comparable port of the producer's check: every string (keys and values) must be well-formed Unicode before serialization; an unpaired surrogate throws `IllFormedStringError` naming the JSON path. Uses `String.prototype.isWellFormed` (present in all modern browsers for the WebCrypto path) with the same dependency-free O(n) `charCodeAt` fallback as `@makerchecker/shared`. Still zero-dependency and isomorphic; `verifier.html`'s inline port gets the same check.
- **`src/verify-core.js`** — maps the throw to a distinct machine-readable verdict: `{ ok:false, reasonCode:"ill_formed_string", failedSeq, path, reason }`, for both event hashing and the manifest signing string. Documented in the README as a **spec-violation verdict distinct from tamper**: nothing is proven altered — the bundle violates the spec's I-JSON requirement, its hashes were never interoperably defined under RFC 8785, and it can never cross-verify.
- **Vectors** (generated via `scripts/build-vectors.mjs`; `vectors/index.json` regenerated by the script, never edited by hand):
  - `ill-formed-string.json` — exactly the bundle the buggy pre-I-JSON JS producer would have signed: the stored hash is over the ES2019 `\ud800`-escape bytes and the payload ships the actual lone surrogate. Expected verdict: reject with `ill_formed_string` (asserted by reason substring AND `reasonCode` in `scripts/test.mjs`).
  - `unicode-literal.json` — POSITIVE: astral emoji U+1F600 plus an NFC/NFD pair (`U+00E9` vs `U+0065 U+0301`) hashed over the literal code points; verifies OK, proving no escaping beyond the mandatory set and no Unicode normalization.

## Why

RFC 8785 presumes I-JSON input; a lone surrogate (API-reachable via `JSON.parse('{"note":"\ud800"}')`) was serialized by the JS canonicalizers as the `\ud800` escape — bytes Python/Go RFC 8785 implementations do not reproduce — so such a bundle "verified" only under JS semantics. Fail closed: the producer now rejects it at ingress (#77) and this verifier rejects any legacy bundle containing one with a verdict that auditors can distinguish from tamper.

## Verification

`node scripts/test.mjs` — all vectors pass:

```
wrote 12 conformance cases to .../vectors
  ok  valid-full.json -> pass (8 events)
  ok  valid-run.json -> pass (7 events)
  ok  valid-full.json [pin instance-pubkey.pem] -> pass (8 events)
  ok  tampered-payload.json -> fail (event seq 7 hash mismatch (row tampered))
  ok  tampered-signature.json -> fail (manifest signature invalid)
  ok  truncated.json -> fail (event count 7 != manifest count 8)
  ok  reordered.json -> fail (event hash set does not match the signed digest)
  ok  foreign-run-event.json -> fail (event seq 99 does not belong to run 22222222-2222-4222-8222-222222222222)
  ok  wrong-key.json -> pass (8 events)
  ok  wrong-key.json [pin instance-pubkey.pem] -> fail (manifest public key does not match the pinned key)
  ok  unicode-literal.json -> pass (9 events)
  ok  ill-formed-string.json -> fail (event seq 9 contains an ill-formed string (unpaired surrogate) at $.payload.note: the spec requires I-JSON (RFC 7493) input, so this bundle can never cross-verify)

12/12 conformance cases passed
```

Cross-check: the same adversarial set through PR #77's `@makerchecker/shared` `canonicalJson` (compiled from `fix/ijson-well-formed-strings`) and this verifier port — byte-identical outputs for valid inputs, identical rejection (same class, message, path) for ill-formed ones:

```
== valid inputs: byte-identical output ==
  ok  astral pair U+1F600
        shared:   sha256=2efc786ae9ac4504bf2253d1b4d8ac1eae8a99a722a9d9f7721e56f4fae4e0c7 bytes=7b227061796c6f6164223a7b22656d6f6a69223a22f09f9880227d7d...
        verifier: sha256=2efc786ae9ac4504bf2253d1b4d8ac1eae8a99a722a9d9f7721e56f4fae4e0c7 bytes=7b227061796c6f6164223a7b22656d6f6a69223a22f09f9880227d7d...
  ok  NFC/NFD pair
        shared:   sha256=79eae438d105e852f86ea598ffdda91643386fad0b4f336b941528d30fbf1558 bytes=7b226e6663223a22c3a9222c226e6664223a2265cc81227d...
        verifier: sha256=79eae438d105e852f86ea598ffdda91643386fad0b4f336b941528d30fbf1558 bytes=7b226e6663223a22c3a9222c226e6664223a2265cc81227d...
  ok  astral in key + value
        shared:   sha256=917c2edd249830eb7b5e689307fc88544506b393c5cc6f72032c8478e60fbd07 bytes=7b226bf09f9880223a5b22f48fbfbf222c22f09f9880225d7d...
        verifier: sha256=917c2edd249830eb7b5e689307fc88544506b393c5cc6f72032c8478e60fbd07 bytes=7b226bf09f9880223a5b22f48fbfbf222c22f09f9880225d7d...
  ok  mixed realistic event
        shared:   sha256=007f25f05f423526a8cf47f3386c6ca5bf00127288d96ac96349bbe33fdcd0da bytes=7b226163746f72223a7b226b696e64223a226167656e74222c226e616d65223a...
        verifier: sha256=007f25f05f423526a8cf47f3386c6ca5bf00127288d96ac96349bbe33fdcd0da bytes=7b226163746f72223a7b226b696e64223a226167656e74222c226e616d65223a...
== ill-formed inputs: identical rejection (class, message, path) ==
  ok  lone high surrogate (API-reachable)   -> IllFormedStringError: ... at $.payload.note   (both)
  ok  lone low surrogate                    -> IllFormedStringError: ... at $.v              (both)
  ok  reversed pair                         -> IllFormedStringError: ... at $[0]             (both)
  ok  high + non-low                        -> IllFormedStringError: ... at $.v              (both)
  ok  unpaired in a KEY                     -> IllFormedStringError: ... at $.\ud800k        (both)
  ok  deep nested mixed                     -> IllFormedStringError: ... at $.a.b[1].c       (both)

CROSS-CHECK PASS: 4 valid inputs byte-identical, 6 ill-formed inputs identically rejected
```

The `charCodeAt` fallback (used when `isWellFormed` is absent) agrees with the native path on all 8 probe cases, and `verifier.html`'s inline module passes `node --check`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


## Corpus determinism

An adversarial review found the corpus was not actually pinnable: the generator drew a fresh Ed25519 keypair and random UUIDs each run (any regeneration churned every vector byte), `npm test` regenerated in place (committed fixtures were never tested and testing dirtied the tree), and the two `pinKey` cases read a gitignored `instance-pubkey.pem`, so a fresh clone could only run 10 of 12 cases. Fixed while the corpus is still unpublished:

- **Deterministic generator** — bundles are signed with the committed `vectors/test-fixture-signing-key.pem`, a **deliberately public** test fixture (its seed is SHA-256 of a documented namespace string, so even the key is auditable); the attacker key and all event UUIDs are likewise derived from SHA-256 of fixed namespace strings. Two runs are byte-identical, so external implementers can pin the committed files by hash.
- **Frozen corpus, proven on every test run** — `scripts/test.mjs` now regenerates into a temp directory, byte-compares every file against the committed `vectors/`, then runs all 12 conformance cases against the **committed** fixtures (both `pinKey` cases against the committed `instance-pubkey.pem`), and asserts `git status` is left untouched.
- **`.gitignore`/`.gitleaks.toml`** — `packages/proof-verifier/vectors/*.pem` is un-ignored so both PEMs ship; the existing `vectors/.*` gitleaks path allowlist covers the fixture key (comment updated to say so), and the allowlisted example fingerprint is updated to the new key's (`bb48c332…7fc889d`). `gitleaks detect` over the commit: no leaks.
- One final regeneration is committed (new `valid-full.json` headHash `4c5e1a8a2c226d34de9774cd0e0a0883e2fc7963197d2c5eeb68e02d4474d46c`); the README documents the corpus as deterministic and frozen. `node scripts/test.mjs` passes 12/12 twice with byte-stable vectors; `packages/obligations` and `packages/validation-kit` suites still pass against the regenerated bundles.
