### PR TITLE
fix(release): build through turbo so the SDK compiles before the connectors

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -56,12 +56,17 @@ jobs:
           corepack pnpm -r exec -- npm pkg set version="$VERSION"
 
       - name: Build publishable packages
+        # Build through turbo, not raw `pnpm --filter build`, so the dependency
+        # graph is ordered: turbo's build task is dependsOn ["^build"], which
+        # compiles the SDK (and any shared workspace deps) before the connectors
+        # that import its types. The raw pnpm filter did not guarantee this, so
+        # the connectors' tsc could race ahead of the SDK's dist/ and fail with
+        # "Cannot find module '@makerchecker/sdk'".
         run: >
-          corepack pnpm
-          --filter "@makerchecker/sdk..."
-          --filter "@makerchecker/connector-claude-agent..."
-          --filter "@makerchecker/connector-langchain..."
-          build
+          corepack pnpm exec turbo run build
+          --filter=@makerchecker/sdk
+          --filter=@makerchecker/connector-claude-agent
+          --filter=@makerchecker/connector-langchain
 
       - name: Publish to npm with provenance
         run: corepack pnpm -r publish --access public --provenance --no-git-checks


### PR DESCRIPTION
## The failure
The v1.1 release failed with:
```
packages/connector-langchain build: src/index.ts(26,8): error TS2307: Cannot find module '@makerchecker/sdk' or its corresponding type declarations.
```

## Root cause
The release job built the publishable packages with a raw `pnpm --filter "…" build`, which does not deterministically order the workspace graph. The connectors import `@makerchecker/sdk`'s types (the SDK exposes them only via its `exports` field, i.e. `dist/index.d.ts`), so a connector's `tsc` can start before the SDK has emitted `dist/`. It is a race: it passes locally but lost the race in CI on the v1.1 tag.

The repo already has the right ordering tool. `turbo.json` declares `build` with `dependsOn: ["^build"]`, and the root `build` script is `turbo run build`. The release step just was not using it.

## The fix
Build the publishable packages through turbo, so the SDK (and any shared workspace deps) compile before the connectors, deterministically.

## Verification
On a clean `pnpm install --frozen-lockfile`, with every package version bumped to `1.1` exactly as the release does:
- old raw command: passes locally but is a race (it lost that race in CI).
- new turbo command: `Tasks: 3 successful, 3 total`, and `packages/sdk/dist/index.d.ts`, `packages/connector-langchain/dist/index.js`, and `packages/connector-claude-agent/dist/index.js` are all emitted.

## After merge
Re-run the release: delete and re-push `v1.1` (or push `v1.1.1`). Note the separate PyPI step still needs the pending Trusted Publisher configured on pypi.org (project `makerchecker`, owner `sammysltd`, repo `MakerChecker`, workflow `release.yml`, environment `pypi`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)